### PR TITLE
Probe the new ignore functionality and add standardised tests

### DIFF
--- a/R/check.R
+++ b/R/check.R
@@ -74,7 +74,7 @@ check.ignore <- function(ignore, data) {
       ") does not match nrow(data) (", nrow(data), ")."
     )
   }
-  if (sum(ignore) < 10L) {
+  if (sum(!ignore) < 10L) {
     warning(
       "Fewer than 10 rows for fitting the imputation model. Are you sure?",
       call. = FALSE

--- a/R/initialize.imp.R
+++ b/R/initialize.imp.R
@@ -1,5 +1,5 @@
-initialize.imp <- function(data, m, where, blocks, visitSequence,
-                           method, nmis, data.init, ignore) {
+initialize.imp <- function(data, m, ignore, where, blocks, visitSequence,
+                           method, nmis, data.init) {
   imp <- vector("list", ncol(data))
   names(imp) <- names(data)
   r <- !is.na(data)

--- a/R/mice.mids.R
+++ b/R/mice.mids.R
@@ -100,9 +100,9 @@ mice.mids <- function(obj, newdata = NULL, maxit = 1, printFlag = TRUE, ...) {
   from <- obj$iteration + 1
   to <- from + maxit - 1
   q <- sampler(
-    obj$data, obj$m, where, imp, blocks, obj$method,
-    obj$visitSequence, obj$predictorMatrix,
-    obj$formulas, obj$blots, obj$post, obj$ignore,
+    obj$data, obj$m, obj$ignore, where, imp, blocks, 
+    obj$method, obj$visitSequence, obj$predictorMatrix,
+    obj$formulas, obj$blots, obj$post, 
     c(from, to), printFlag, ...
   )
 

--- a/R/mice.mids.R
+++ b/R/mice.mids.R
@@ -65,7 +65,7 @@ mice.mids <- function(obj, newdata = NULL, maxit = 1, printFlag = TRUE, ...) {
   # obj contains training data, newdata contains test data
   # overwrite obj with combined obj + imp.newdata
   if (!is.null(newdata)) {
-    ignore <- rep(FALSE, nrow(obj$data))
+    ignore <- obj$ignore
     if (!is.null(obj$ignore)) ignore <- obj$ignore
 
     newdata <- check.newdata(newdata, obj$data)

--- a/R/mice.mids.R
+++ b/R/mice.mids.R
@@ -54,7 +54,9 @@ mice.mids <- function(obj, newdata = NULL, maxit = 1, printFlag = TRUE, ...) {
     if (!is.null(obj$ignore)) ignore <- obj$ignore
     
     newdata <- check.newdata(newdata, obj$data)
-    imp.newdata <- mice(newdata, m = obj$m, maxit = 0)
+    imp.newdata <- mice(newdata, m = obj$m, maxit = 0,
+                        remove.collinear = FALSE, 
+                        remove.constant = FALSE)
     obj <- withCallingHandlers(
       rbind.mids(obj, imp.newdata),
       warning = function(w) {

--- a/R/mice.mids.R
+++ b/R/mice.mids.R
@@ -70,7 +70,16 @@ mice.mids <- function(obj, newdata = NULL, maxit = 1, printFlag = TRUE, ...) {
 
     newdata <- check.newdata(newdata, obj$data)
     imp.newdata <- mice(newdata, m = obj$m, maxit = 0)
-    obj <- rbind.mids(obj, imp.newdata)
+    obj <- withCallingHandlers(
+      rbind.mids(obj, imp.newdata),
+      warning = function(w) {
+        # Catch warnings concerning iterations, these differ by design 
+        if(!grepl("iterations differ", w$message)){
+           warning(w$message)
+         }
+        invokeRestart("muffleWarning")
+      }
+    )
 
     # ignore newdata for model building, but do impute
     obj$ignore <- c(ignore, rep(TRUE, nrow(newdata)))

--- a/R/mice.mids.R
+++ b/R/mice.mids.R
@@ -46,22 +46,7 @@ mice.mids <- function(obj, newdata = NULL, maxit = 1, printFlag = TRUE, ...) {
   if (!is.mids(obj)) {
     stop("Object should be of type mids.")
   }
-  if (maxit < 1) {
-    return(obj)
-  }
-
-  loggedEvents <- obj$loggedEvents
-  state <- list(
-    it = 0, im = 0, co = 0, dep = "", meth = "",
-    log = !is.null(loggedEvents)
-  )
-  if (is.null(loggedEvents)) {
-    loggedEvents <- data.frame(
-      it = 0, im = 0, co = 0, dep = "",
-      meth = "", out = ""
-    )
-  }
-
+  
   # obj contains training data, newdata contains test data
   # overwrite obj with combined obj + imp.newdata
   if (!is.null(newdata)) {
@@ -79,9 +64,25 @@ mice.mids <- function(obj, newdata = NULL, maxit = 1, printFlag = TRUE, ...) {
         }
       }
     )
-
+    
     # ignore newdata for model building, but do impute
     obj$ignore <- c(ignore, rep(TRUE, nrow(newdata)))
+  }
+  
+  if (maxit < 1) {
+    return(obj)
+  }
+
+  loggedEvents <- obj$loggedEvents
+  state <- list(
+    it = 0, im = 0, co = 0, dep = "", meth = "",
+    log = !is.null(loggedEvents)
+  )
+  if (is.null(loggedEvents)) {
+    loggedEvents <- data.frame(
+      it = 0, im = 0, co = 0, dep = "",
+      meth = "", out = ""
+    )
   }
 
   # Initialize local variables

--- a/R/mice.mids.R
+++ b/R/mice.mids.R
@@ -65,9 +65,9 @@ mice.mids <- function(obj, newdata = NULL, maxit = 1, printFlag = TRUE, ...) {
   # obj contains training data, newdata contains test data
   # overwrite obj with combined obj + imp.newdata
   if (!is.null(newdata)) {
-    ignore <- obj$ignore
+    ignore <- rep(FALSE, nrow(obj$data))
     if (!is.null(obj$ignore)) ignore <- obj$ignore
-
+    
     newdata <- check.newdata(newdata, obj$data)
     imp.newdata <- mice(newdata, m = obj$m, maxit = 0)
     obj <- withCallingHandlers(

--- a/R/mice.mids.R
+++ b/R/mice.mids.R
@@ -73,11 +73,10 @@ mice.mids <- function(obj, newdata = NULL, maxit = 1, printFlag = TRUE, ...) {
     obj <- withCallingHandlers(
       rbind.mids(obj, imp.newdata),
       warning = function(w) {
-        # Catch warnings concerning iterations, these differ by design 
-        if(!grepl("iterations differ", w$message)){
-           warning(w$message)
-         }
-        invokeRestart("muffleWarning")
+        if(grepl("iterations differ", w$message)){
+          # Catch warnings concerning iterations, these differ by design 
+          invokeRestart("muffleWarning")
+        }
       }
     )
 

--- a/R/rbind.R
+++ b/R/rbind.R
@@ -96,6 +96,9 @@ rbind.mids <- function(x, y = NULL, ...) {
   wy <- matrix(FALSE, nrow = nrow(y), ncol = ncol(y))
   where <- rbind(x$where, wy)
 
+  # ignore argument: include all new values
+  ignore <- c(x$ignore, rep(FALSE, nrow(y)))
+  
   # The number of imputations in the new midsobject is equal to that in x.
   m <- x$m
 
@@ -107,7 +110,6 @@ rbind.mids <- function(x, y = NULL, ...) {
   post <- x$post
   formulas <- x$formulas
   blots <- x$blots
-  ignore <- x$ignore
   predictorMatrix <- x$predictorMatrix
   visitSequence <- x$visitSequence
 

--- a/R/rbind.R
+++ b/R/rbind.R
@@ -12,7 +12,9 @@
 #' If \code{y} is not a \code{mids} object, the columns of \code{x$data}
 #' and \code{y} should match. The \code{where} matrix for \code{y} is set
 #' to \code{FALSE}, signaling that any missing values
-#' in \code{y} were not imputed.
+#' in \code{y} were not imputed. The \code{ignore} vector for \code{y} is
+#' set to \code{FALSE}, elements of \code{y} will therefore influence 
+#' the parameters of the imputation model in future iterations.
 #'
 #' @param x A \code{mids} object.
 #' @param y A \code{mids} object, or a \code{data.frame}, \code{matrix}, \code{factor}

--- a/R/sampler.R
+++ b/R/sampler.R
@@ -1,8 +1,8 @@
 # The sampler controls the actual Gibbs sampling iteration scheme.
 # This function is called by mice and mice.mids
-sampler <- function(data, m, where, imp, blocks, method, visitSequence,
-                    predictorMatrix, formulas, blots, post, ignore,
-                    fromto, printFlag, ...) {
+sampler <- function(data, m, ignore, where, imp, blocks, method, 
+                    visitSequence, predictorMatrix, formulas, blots, 
+                    post, fromto, printFlag, ...) {
   from <- fromto[1]
   to <- fromto[2]
   maxit <- to - from + 1

--- a/man/mice.Rd
+++ b/man/mice.Rd
@@ -10,6 +10,7 @@ mice(
   m = 5,
   method = NULL,
   predictorMatrix,
+  ignore = NULL,
   where = NULL,
   blocks,
   visitSequence = NULL,
@@ -21,7 +22,6 @@ mice(
   printFlag = TRUE,
   seed = NA,
   data.init = NULL,
-  ignore = NULL,
   ...
 )
 }
@@ -49,6 +49,17 @@ By default, the \code{predictorMatrix} is a square matrix of \code{ncol(data)}
 rows and columns with all 1's, except for the diagonal.
 Note: For two-level imputation models (which have \code{"2l"} in their names)
 other codes (e.g, \code{2} or \code{-2}) are also allowed.}
+
+\item{ignore}{A logical vector of \code{length(n)} elements indicating
+which rows are ignored when creating the imputation model. The default
+\code{NULL} includes all rows that have an observed value of the variable
+to imputed. Rows with \code{ignore} set to \code{TRUE} do not influence the
+parameters of the imputation model, but are still imputed. We may use the
+\code{ignore} argument to split \code{data} into a training set (on which the
+imputation model is built) and a test set (that does not influence the
+imputation model estimates).
+Note: Multivariate imputation methods, like \code{mice.impute.jomoImpute()}
+or \code{mice.impute.panImpute()}, do not honour the \code{ignore} argument.}
 
 \item{where}{A data frame or matrix with logicals of the same dimensions
 as \code{data} indicating where in the data the imputations should be
@@ -123,17 +134,6 @@ iterative process.  The default \code{NULL} implies that starting imputation
 are created by a simple random draw from the data. Note that specification of
 \code{data.init} will start all \code{m} Gibbs sampling streams from the same
 imputation.}
-
-\item{ignore}{A logical vector of \code{length(n)} elements indicating
-which rows are ignored when creating the imputation model. The default
-\code{NULL} includes all rows that have an observed value of the variable
-to imputed. Rows with \code{ignore} set to \code{TRUE} do not influence the
-parameters of the imputation model, but are still imputed. We may use the
-\code{ignore} argument to split \code{data} into a training set (on which the
-imputation model is built) and a test set (that does not influence the
-imputation model estimates).
-Note: Multivariate imputation methods, like \code{mice.impute.jomoImpute()}
-or \code{mice.impute.panImpute()}, do not honour the \code{ignore} argument.}
 
 \item{...}{Named arguments that are passed down to the univariate imputation
 functions.}

--- a/man/rbind.mids.Rd
+++ b/man/rbind.mids.Rd
@@ -32,7 +32,9 @@ columns of \code{x$data} and \code{y$data} should match.
 If \code{y} is not a \code{mids} object, the columns of \code{x$data}
 and \code{y} should match. The \code{where} matrix for \code{y} is set
 to \code{FALSE}, signaling that any missing values
-in \code{y} were not imputed.
+in \code{y} were not imputed. The \code{ignore} vector for \code{y} is
+set to \code{FALSE}, elements of \code{y} will therefore influence 
+the parameters of the imputation model in future iterations.
 }
 \note{
 The function construct the elements of the new \code{mids} object as follows:

--- a/tests/testthat/test-mice.R
+++ b/tests/testthat/test-mice.R
@@ -179,7 +179,7 @@ test_that("`where` produces correct number of imputes", {
 context("mice: ignore")
 
 # # all TRUE
-test_that("throws errors and warnings", {
+test_that("`ignore` throws appropriate errors and warnings", {
   expect_error(
     mice(nhanes, maxit = 1, m = 1, print = FALSE, seed = 1, ignore = TRUE),
     "does not match"
@@ -220,7 +220,7 @@ test_that("`ignore` changes the imputation results", {
 })
 
 
-add_pmm <- data.frame(
+artificial <- data.frame(
   age = c(1, 1),
   bmi = c(NA, 40.0), 
   hyp = c(1, 1),
@@ -228,50 +228,18 @@ add_pmm <- data.frame(
   row.names = paste0("a", 1:2)
 )
 
-imp_pmm1 <- mice(
-  rbind(nhanes, add_pmm), 
-  maxit = 1, m = 1, print = FALSE, seed = 1, donors = 1L
+imp1 <- mice(
+  rbind(nhanes, artificial), 
+  maxit = 1, m = 1, print = FALSE, seed = 1, donors = 1L, matchtype = 0
 )
 
-imp_pmm2 <- mice(
-  rbind(nhanes, add_pmm), 
-  maxit = 1, m = 1, print = FALSE, seed = 1, donors = 1L,
-  ignore = c(rep(FALSE, nrow(nhanes)), rep(TRUE, nrow(add_pmm)))
+imp2 <- mice(
+  rbind(nhanes, artificial), 
+  maxit = 1, m = 1, print = FALSE, seed = 1, donors = 1L, matchtype = 0,
+  ignore = c(rep(FALSE, nrow(nhanes)), rep(TRUE, nrow(artificial)))
 )
 
 test_that("`ignore` works with pmm", {
-  expect_equal(complete(imp_pmm1)["a1", "bmi"], 40.0)
-  expect_failure(expect_equal(complete(imp_pmm2)["a1", "bmi"], 40.0))
+  expect_equal(complete(imp1)["a1", "bmi"], 40.0)
+  expect_failure(expect_equal(complete(imp2)["a1", "bmi"], 40.0))
 })
-
-
-
-lastSeedValue <- .Random.seed
-set.seed(1)
-add_norm <- nhanes
-rownames(add_norm) <- paste0("a", rownames(nhanes))
-add_norm$bmi <- c(NA, rnorm(nrow(nhanes)-1, mean = 9999, sd = 20))
-assign(".Random.seed", lastSeedValue, pos = 1)
-
-imp_norm1 <- mice(
-  rbind(nhanes, add_norm), 
-  maxit = 1, m = 1, print = FALSE, seed = 1, method = "norm"
-)
-
-imp_norm2 <- mice(
-  rbind(nhanes, add_norm), 
-  maxit = 1, m = 1, print = FALSE, seed = 1, method = "norm",
-  ignore = c(rep(FALSE, nrow(nhanes)), rep(TRUE, nrow(add_norm)))
-)
-
-test_that("`ignore` works with norm", {
-  expect_true(complete(imp_norm1)["a1", "bmi"] > 100)
-  expect_true(complete(imp_norm2)["a1", "bmi"] < 100)
-})
-
-
-
-
-
-
-

--- a/tests/testthat/test-mice.R
+++ b/tests/testthat/test-mice.R
@@ -229,14 +229,14 @@ add_pmm <- data.frame(
 )
 
 imp_pmm1 <- mice(
-  rbind(add, nhanes), 
+  rbind(add_pmm, nhanes), 
   maxit = 1, m = 1, print = FALSE, seed = 1, donors = 1L
 )
 
 imp_pmm2 <- mice(
   rbind(add_pmm, nhanes), 
   maxit = 1, m = 1, print = FALSE, seed = 1, donors = 1L,
-  ignore = c(rep(TRUE, nrow(add)), rep(FALSE, nrow(nhanes)))
+  ignore = c(rep(TRUE, nrow(add_pmm)), rep(FALSE, nrow(nhanes)))
 )
 
 test_that("`ignore` works with pmm", {

--- a/tests/testthat/test-mice.R
+++ b/tests/testthat/test-mice.R
@@ -196,6 +196,8 @@ test_that("`ignore` throws appropriate errors and warnings", {
 })
 
 
+# Check that the ignore argument is taken into account when
+# calculating the results
 # # all FALSE
 imp1 <- mice(nhanes, 
   maxit = 1, m = 1, print = FALSE, seed = 1,
@@ -205,10 +207,8 @@ imp1 <- mice(nhanes,
 # # NULL
 imp2 <- mice(nhanes, maxit = 1, m = 1, print = FALSE, seed = 1)
 
-
 # # alternate
 alternate <- rep(c(TRUE, FALSE), nrow(nhanes))[1:nrow(nhanes)]
-
 imp3 <- mice(nhanes, 
   maxit = 0, m = 1, print = FALSE, seed = 1,
   ignore = alternate
@@ -220,6 +220,8 @@ test_that("`ignore` changes the imputation results", {
 })
 
 
+# Check that rows flagged as ignored are indeed ignored by the
+# univariate sampler in mice
 artificial <- data.frame(
   age = c(1, 1),
   bmi = c(NA, 40.0), 

--- a/tests/testthat/test-mice.R
+++ b/tests/testthat/test-mice.R
@@ -225,24 +225,53 @@ add_pmm <- data.frame(
   bmi = c(NA, 40.0), 
   hyp = c(1, 1),
   chl = c(200, 200), 
-  row.names = nrow(nhanes) + 1:2
+  row.names = paste0("a", 1:2)
 )
 
 imp_pmm1 <- mice(
-  rbind(add_pmm, nhanes), 
+  rbind(nhanes, add_pmm), 
   maxit = 1, m = 1, print = FALSE, seed = 1, donors = 1L
 )
 
 imp_pmm2 <- mice(
-  rbind(add_pmm, nhanes), 
+  rbind(nhanes, add_pmm), 
   maxit = 1, m = 1, print = FALSE, seed = 1, donors = 1L,
-  ignore = c(rep(TRUE, nrow(add_pmm)), rep(FALSE, nrow(nhanes)))
+  ignore = c(rep(FALSE, nrow(nhanes)), rep(TRUE, nrow(add_pmm)))
 )
 
 test_that("`ignore` works with pmm", {
-  expect_equal(complete(imp_pmm1)$bmi[1], 40.0)
-  expect_failure(expect_equal(complete(imp_pmm2)$bmi[1], 40.0))
+  expect_equal(complete(imp_pmm1)["a1", "bmi"], 40.0)
+  expect_failure(expect_equal(complete(imp_pmm2)["a1", "bmi"], 40.0))
 })
+
+
+
+lastSeedValue <- .Random.seed
+set.seed(1)
+add_norm <- nhanes
+rownames(add_norm) <- paste0("a", rownames(nhanes))
+add_norm$bmi <- c(NA, rnorm(nrow(nhanes)-1, mean = 9999, sd = 20))
+assign(".Random.seed", lastSeedValue, pos = 1)
+
+imp_norm1 <- mice(
+  rbind(nhanes, add_norm), 
+  maxit = 1, m = 1, print = FALSE, seed = 1, method = "norm"
+)
+
+imp_norm2 <- mice(
+  rbind(nhanes, add_norm), 
+  maxit = 1, m = 1, print = FALSE, seed = 1, method = "norm",
+  ignore = c(rep(FALSE, nrow(nhanes)), rep(TRUE, nrow(add_norm)))
+)
+
+test_that("`ignore` works with norm", {
+  expect_true(complete(imp_norm1)["a1", "bmi"] > 100)
+  expect_true(complete(imp_norm2)["a1", "bmi"] < 100)
+})
+
+
+
+
 
 
 

--- a/tests/testthat/test-newdata.R
+++ b/tests/testthat/test-newdata.R
@@ -1,0 +1,38 @@
+context("mice.mids: newdata")
+
+# Check that mice.mids correctly appends the newdata to the
+# existing mids object
+set.seed(1)
+init0 <- mice(nhanes, maxit = 1, m = 1, print = FALSE)
+
+set.seed(2)
+init1 <- mice(nhanes, maxit = 0, m = 1, print = FALSE)
+init1$ignore <- rep(FALSE, nrow(nhanes))
+
+set.seed(2)
+init2 <- mice.mids(init0, newdata = nhanes, maxit = 0, print = FALSE)
+
+test_that("`newdata` works like rbind with ignore", {
+  expect_equal(complete(rbind(init0, init1)), complete(init2))
+})
+
+
+# Check that rows flagged as ignored are indeed ignored by the
+# univariate sampler in mice.mids
+artificial <- data.frame(
+  age = c(1, 1),
+  bmi = c(NA, 40.0), 
+  hyp = c(1, 1),
+  chl = c(200, 200), 
+  row.names = paste0("a", 1:2)
+)
+
+imp1 <- mice(nhanes, maxit = 1, m = 1, print = FALSE, seed = 1, 
+             donors = 1L, matchtype = 0)
+
+set.seed(2)
+imp2 <- mice.mids(imp1, newdata = artificial, maxit = 1, print = FALSE)
+
+test_that("`ignore` works with pmm", {
+  expect_failure(expect_equal(complete(imp2)["a1", "bmi"], 40.0))
+})

--- a/tests/testthat/test-newdata.R
+++ b/tests/testthat/test-newdata.R
@@ -3,7 +3,7 @@ context("mice.mids: newdata")
 # Check that mice.mids correctly appends the newdata to the
 # existing mids object
 set.seed(1)
-init0 <- mice(nhanes, maxit = 1, m = 1, print = FALSE)
+init0 <- mice(nhanes, maxit = 0, m = 1, print = FALSE)
 
 set.seed(2)
 init1 <- mice(nhanes, maxit = 0, m = 1, print = FALSE)

--- a/tests/testthat/test-rbind.R
+++ b/tests/testthat/test-rbind.R
@@ -19,8 +19,8 @@ nh3 <- nhanes
 colnames(nh3) <- c("AGE", "bmi", "hyp", "chl")
 imp7 <- mice(nh3[14:25, ], m = 2, maxit = 2, print = FALSE)
 expect_warning(imp8 <<- mice(nhanes[1:13, ], m = 2, maxit = 2, print = FALSE))
-imp8 <- mice(nhanes, m = 2, maxit = 1, print = FALSE, 
-             ignore = c(rep(FALSE, 13), rep(TRUE, 12)))
+imp9 <- mice(nhanes, m = 2, maxit = 1, print = FALSE, 
+             ignore = c(rep(FALSE, 20), rep(TRUE, 5)))
 
 mylist <- list(age = NA, bmi = NA, hyp = NA, chl = NA)
 nhalf <- nhanes[13:25, ]
@@ -41,7 +41,7 @@ test_that("throws warning", {
     "iterations differ, so no convergence diagnostics calculated"
   )
   expect_warning(
-    rbind(imp5, imp8),
+    rbind(imp5, imp9),
     "iterations differ, so no convergence diagnostics calculated"
   )
 })
@@ -50,7 +50,7 @@ r1 <- rbind(imp8, imp5)
 r2 <- rbind(imp1, mylist)
 r3 <- rbind(imp1, nhalf)
 r4 <- rbind(imp1, imp2)
-r5 <- rbind(imp2, imp8)
+r5 <- rbind(imp2, imp9)
 
 test_that("Produces longer imputed data", {
   expect_identical(nrow(complete(r1)), 26L)
@@ -64,7 +64,7 @@ test_that("Constant variables are not imputed", {
 
 test_that("`ignore` is correctly appended", {
   expect_equal(r2$ignore, rep(FALSE, 14))
-  expect_equal(r5$ignore, c(rep(FALSE, 25), rep(TRUE,12)))
+  expect_equal(r5$ignore, c(rep(FALSE, 32), rep(TRUE, 5)))
 })
 
 # r11 <- mice.mids(rbind(imp1, imp5), print = FALSE)

--- a/tests/testthat/test-rbind.R
+++ b/tests/testthat/test-rbind.R
@@ -19,6 +19,8 @@ nh3 <- nhanes
 colnames(nh3) <- c("AGE", "bmi", "hyp", "chl")
 imp7 <- mice(nh3[14:25, ], m = 2, maxit = 2, print = FALSE)
 expect_warning(imp8 <<- mice(nhanes[1:13, ], m = 2, maxit = 2, print = FALSE))
+imp8 <- mice(nhanes, m = 2, maxit = 1, print = FALSE, 
+             ignore = c(rep(FALSE, 13), rep(TRUE, 12)))
 
 mylist <- list(age = NA, bmi = NA, hyp = NA, chl = NA)
 nhalf <- nhanes[13:25, ]
@@ -38,12 +40,17 @@ test_that("throws warning", {
     rbind(imp1, imp5),
     "iterations differ, so no convergence diagnostics calculated"
   )
+  expect_warning(
+    rbind(imp5, imp8),
+    "iterations differ, so no convergence diagnostics calculated"
+  )
 })
 
 r1 <- rbind(imp8, imp5)
 r2 <- rbind(imp1, mylist)
 r3 <- rbind(imp1, nhalf)
 r4 <- rbind(imp1, imp2)
+r5 <- rbind(imp2, imp8)
 
 test_that("Produces longer imputed data", {
   expect_identical(nrow(complete(r1)), 26L)
@@ -53,6 +60,11 @@ test_that("Produces longer imputed data", {
 test_that("Constant variables are not imputed", {
   expect_equal(sum(is.na(complete(r3))), 15L)
   expect_equal(sum(is.na(complete(r4))), 6L)
+})
+
+test_that("`ignore` is correctly appended", {
+  expect_equal(r2$ignore, rep(FALSE, 14))
+  expect_equal(r5$ignore, c(rep(FALSE, 25), rep(TRUE,12)))
 })
 
 # r11 <- mice.mids(rbind(imp1, imp5), print = FALSE)


### PR DESCRIPTION
### Scope
This pull requesst aims to test the recently added functionality to ignore subsets of the data when fitting the imputation models (see #32) and implement standardised tests via `testthat`. It also aims to update the help pages where this hasn't already been done by @stefvanbuuren 

**Note:** This PR does not include additional features discussed in #32, such as `filter.mids`, plots, or vignettes. I will create separate PRs for those later this week.

### Testing
- [x] Create tests for ignore in `mice`

- [x] Create tests for ignore in `mice.mids`

- [x] Create tests for ignore in `rbind.mids` and `rbind.mids.mids`

- [x] Update help pages