### PR TITLE
add drop for tibbles

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -17,3 +17,4 @@ _pkgdown.yaml
 .png
 ^script$
 ^CODE_OF_CONDUCT*
+^mice\.Rproj$

--- a/R/nelsonaalen.R
+++ b/R/nelsonaalen.R
@@ -43,8 +43,8 @@ nelsonaalen <- function(data, timevar, statusvar) {
   }
   timevar <- as.character(substitute(timevar))
   statusvar <- as.character(substitute(statusvar))
-  time <- data[, timevar]
-  status <- data[, statusvar]
+  time <- data[, timevar, drop = TRUE]
+  status <- data[, statusvar, drop = TRUE]
 
   hazard <- survival::basehaz(survival::coxph(survival::Surv(time, status) ~ 1))
   idx <- match(time, hazard[, "time"])


### PR DESCRIPTION
Hi,

I noticed a funny error occurs when `tibble` objects get passed to `nelsonaalen`. The issue is simply that `data.frame` defaults to `drop = TRUE` when a single column is subsetted but `tibble` objects do not. The fix is straightforward and is included in this pull request.

``` r
library(tibble)
library(mice)
#> 
#> Attaching package: 'mice'
#> The following objects are masked from 'package:base':
#> 
#>     cbind, rbind

data <- tribble(
  ~failure, ~time,
  1,    0.1,
  0,    0.1,
  1,    10.84384,
  0,    10.84384,
  1,    5,
  0,    5,
  1,    2,
  1,    6,
  0,    16,
  0,    17,
  0,    6,
  0,    15,
  0,    1,
  0,    1
)

na_var <- nelsonaalen(data = data,
                      timevar = time,
                      statusvar = failure)
#> Error in survival::Surv(time, status): Time variable is not numeric
```

<sup>Created on 2020-09-30 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
