### PR TITLE
tidy.mipo(x, ...) passes ... to summary(x, ...)

### DIFF
--- a/R/tidiers.R
+++ b/R/tidiers.R
@@ -33,7 +33,9 @@ generics::glance
 tidy.mipo <- function(x, conf.int = FALSE, conf.level = .95, ...) {
   out <- summary(x,
     type = "all",
-    conf.int = conf.int, conf.level = conf.level
+    conf.int = conf.int, 
+    conf.level = conf.level,
+    ...
   )
   out$term <- as.character(out$term)
 


### PR DESCRIPTION
This PR changes 2 lines of code.

Motivation: It would often be useful for `tidy.mipo` to pass `...` to `summary`. For example, to use the `exponentiate=TRUE` option in logistic regression:

```r
    library(mice)
    library(tidyverse)
    data("toenail2")

    xdata <- tidyr::complete(toenail2, patientID, visit) %>%
      tidyr::fill(treatment) %>%
      dplyr::select(-time) %>%
      dplyr::mutate(patientID = as.integer(patientID))

    z1imp <- mice(xdata, method = "pmm", maxit = 1, m = 5, seed = 1)
    z1model <- with(z1imp, glm(outcome ~ treatment, binomial))
    z1model.pool <- pool(z1model)

    tidy(z1model.pool)
    #>                   term   estimate  std.error  statistic   p.value            b
    #> 1          (Intercept) -1.2671348 0.07899231 -16.041242 0.0000000 0.0004436482
    #> 2 treatmentterbinafine -0.1558574 0.11681645  -1.334208 0.1835811 0.0014746179
    #>         df dfcom        fmi     lambda m        riv        ubar
    #> 1 425.1451  2056 0.08959265 0.08531989 5 0.09327839 0.005707408
    #> 2 209.9417  2056 0.13784827 0.12967396 5 0.14899469 0.011876541

    tidy(z1model.pool, exponentiate=TRUE)
    #>                   term  estimate  std.error  statistic   p.value            b
    #> 1          (Intercept) 0.2816374 0.07899231 -16.041242 0.0000000 0.0004436482
    #> 2 treatmentterbinafine 0.8556812 0.11681645  -1.334208 0.1835811 0.0014746179
    #>         df dfcom        fmi     lambda m        riv        ubar
    #> 1 425.1451  2056 0.08959265 0.08531989 5 0.09327839 0.005707408
    #> 2 209.9417  2056 0.13784827 0.12967396 5 0.14899469 0.011876541
```