### PR TITLE
Extract nodes from randomForest predictions

### DIFF
--- a/R/mice.impute.rf.R
+++ b/R/mice.impute.rf.R
@@ -59,7 +59,9 @@ mice.impute.rf <- function(y, ry, x, wy = NULL, ntree = 10, ...) {
       ntree = 1, ...
     )
     leafnr <- predict(object = fit, newdata = xobs, nodes = TRUE)
+    leafnr <- as.vector(attr(leafnr, "nodes"))
     nodes <- predict(object = fit, newdata = xmis, nodes = TRUE)
+    nodes <- as.vector(attr(nodes, "nodes"))
     donor <- lapply(nodes, function(s) yobs[leafnr == s])
     return(donor)
   }


### PR DESCRIPTION
Fixes `mice.impute.rf` to use the tree nodes rather than predicted responses to choose donors for imputation. See #288 for details.