### PR TITLE
New mids2spss

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,6 +39,7 @@ Imports:
     dplyr,
     generics,
     graphics,
+    haven,
     lattice,
     methods,
     Rcpp,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,6 @@ Imports:
     dplyr,
     generics,
     graphics,
-    haven,
     lattice,
     methods,
     Rcpp,
@@ -49,6 +48,7 @@ Imports:
     utils
 Suggests:
     broom.mixed,
+    haven,
     knitr,
     lme4,
     MASS,

--- a/R/mids2spss.R
+++ b/R/mids2spss.R
@@ -4,11 +4,8 @@
 #' the data and the SPSS syntax files.
 #'
 #' This function automates most of the work needed to export a \code{mids}
-#' object to SPSS. It uses a modified version of \code{writeForeignSPSS()} from
-#' the \code{foreign} package. The modified version allows for a choice of the
-#' field and decimal separators, and makes some improvements to the formatting,
-#' so that the generated syntax file is amenable to the \code{INCLUDE} statement
-#' in SPSS.
+#' object to SPSS. It uses \code{haven::write_sav()} to facilitate the export to an 
+#' SPSS \code{.sav} or \code{.zsav} file. 
 #'
 #' Below are some things to pay attention to.
 #'
@@ -21,115 +18,50 @@
 #' internal coding of factor levels used in \code{R} is exported. This is
 #' generally acceptable for \code{SPSS}. However, when the data are to be
 #' combined with existing \code{SPSS} data, watch out for any changes in the
-#' factor levels codes. The \code{read.spss()} in package \code{foreign} for
-#' reading \code{.sav} uses its own internal numbering scheme \code{1,2,3,...}
-#' for the levels of a factor. Consequently, changes in factor code can cause
-#' discrepancies in factor level when re-imported to \code{SPSS}. The solution
-#' is to manually recode the factor level in \code{SPSS}.
+#' factor levels codes. 
 #'
 #' \code{SPSS} will recognize the data set as a multiply imputed data set, and
 #' do automatic pooling in procedures where that is supported. Note however that
 #' pooling is an extra option only available to those who license the
 #' \code{MISSING VALUES} module. Without this license, \code{SPSS} will still
-#' recognize the structure of the data, but not do any pooling.
+#' recognize the structure of the data, but it will not pool the multiply imputed 
+#' estimates into a single inference.
 #'
 #' @param imp The \code{imp} argument is an object of class \code{mids},
 #' typically produced by the \code{mice()} function.
-#' @param filedat A character string describing the name of the output data
-#' file.
-#' @param filesps A character string describing the name of the output syntax
-#' file.
+#' @param filename A character string describing the name of the output data
+#' file and its extension.
 #' @param path A character string containing the path of the output file. The
-#' value in \code{path} is appended to \code{filedat} and \code{filesps}. By
+#' value in \code{path} is appended to \code{filedat}. By
 #' default, files are written to the current \code{R} working directory. If
 #' \code{path=NULL} then no file path appending is done.
-#' @param sep The separator between the data fields.
-#' @param dec The decimal separator for numerical data.
-#' @param silent A logical flag stating whether the names of the files should be
+#' @param compress A logical flag stating whether the resulting SPSS set should 
+#' be a compressed \code{.zsav} file.
+#' @param silent A logical flag stating whether the location of the saved file should be
 #' printed.
 #' @return The return value is \code{NULL}.
-#' @author Stef van Buuren, dec 2010.
+#' @author Gerko Vink, dec 2020.
 #' @seealso \code{\link[=mids-class]{mids}}
 #' @keywords manip
 #' @export
-mids2spss <- function(imp, filedat = "midsdata.txt", filesps = "readmids.sps",
-                      path = getwd(), sep = "\t", dec = ".", silent = FALSE) {
-  if (!is.mids(imp)) stop("Exports only objects of class 'mids'.")
-  imputed <- complete(imp, "long", include = TRUE)[, -2]
-  names(imputed)[1] <- "Imputation_"
-  if (!is.null(path)) {
-    filedat <- file.path(path, filedat)
-    filesps <- file.path(path, filesps)
-  }
-  miceWriteForeignSPSS(imputed, filedat, filesps,
-    varnames = names(imputed), sep = sep, dec = dec
-  )
-  if (!silent) {
-    cat("Data values written to", filedat, "\n")
-    cat("Syntax file written to", filesps, "\n")
-  }
-}
-
-# adapted version of writeForeignSPSS from foreign package to write mids-objects
-miceWriteForeignSPSS <- function(df, datafile, codefile,
-                                 varnames = NULL, dec = ".", sep = "\t") {
-  adQuote <- function(x) paste0("\"", x, "\"")
-  dfn <- lapply(df, function(x) if (is.factor(x)) as.numeric(x) else x)
-  eol <- paste0(sep, "\n")
-  write.table(dfn,
-    file = datafile, row.names = FALSE, col.names = FALSE,
-    sep = sep, dec = dec, quote = FALSE, na = "", eol = eol
-  )
-  varlabels <- names(df)
-  if (is.null(varnames)) {
-    varnames <- abbreviate(names(df), 8L)
-    if (any(nchar(varnames) > 8L)) {
-      stop("I cannot abbreviate the variable names to eight or fewer letters")
-    }
-    if (any(varnames != varlabels)) {
-      warning("some variable names were abbreviated")
-    }
-  }
-  varnames <- gsub("[^[:alnum:]_\\$@#]", "\\.", varnames)
-  dl.varnames <- varnames
-  chv <- vapply(df, is.character, logical(1))
-  if (any(chv)) {
-    lengths <- vapply(df[chv], function(v) max(nchar(v)), numeric(1))
-    if (any(lengths > 255L)) {
-      stop("Cannot handle character variables longer than 255")
-    }
-    lengths <- paste0("(A", lengths, ")")
-    star <- ifelse(c(FALSE, diff(which(chv) > 1L)), " *",
-      " "
-    )
-    dl.varnames[chv] <- paste(star, dl.varnames[chv], lengths)
-  }
-  if (sep == "\t") freefield <- " free (TAB)\n"
-  if (sep != "\t") freefield <- cat(' free (\"', sep, '\")\n', sep = "")
-  cat("DATA LIST FILE=", adQuote(datafile), freefield,
-    file = codefile
-  )
-  cat(" /", dl.varnames, ".\n\n", file = codefile, append = TRUE, fill = 60, labels = " ")
-  cat("VARIABLE LABELS\n", file = codefile, append = TRUE)
-  cat(" ", paste(varnames, adQuote(varlabels), "\n"), ".\n",
-    file = codefile,
-    append = TRUE
-  )
-  factors <- vapply(df, is.factor, logical(1))
-  if (any(factors)) {
-    cat("\nVALUE LABELS\n", file = codefile, append = TRUE)
-    for (v in which(factors)) {
-      cat(" /", varnames[v], "\n", file = codefile, append = TRUE)
-      levs <- levels(df[[v]])
-      for (u in seq_along(levs)) {
-        cat(paste("  ", seq_along(levs)[u], adQuote(levs)[u], sep = " "),
-          file = codefile, append = TRUE, fill = 60
-        )
+mids2spss <- function(imp, filename="midsdata",
+                      path=getwd(), compress = FALSE, silent=FALSE) {
+  .id <- NULL # avoid empty global variable binding
+  #extract a completed dataset (long format - all imputations stacked)
+  #rename the .imp variable to imputation_, such that SPSS can identify a multiply imputed dataset
+  out <-
+    imp %>%
+    complete(action = "long", include = TRUE) %>%
+    dplyr::select(-.id) %>%
+    dplyr::rename("Imputation_" = ".imp")
+  #write the data to a .sav file with package haven and print (optional) the saved location
+  if (!compress){
+    whereto <- paste(path, "/", filename, ".sav", sep = "")
+  } else { 
+      whereto <- paste(path, "/", filename, ".zsav", sep = "")
       }
-    }
-    cat(" .\n", file = codefile, append = TRUE)
+  haven::write_sav(data = out, path = whereto, compress = compress)  
+  if (!silent) {
+    cat("SPSS file written to", whereto, "\n")
   }
-  cat("\nEXECUTE.\n", file = codefile, append = TRUE)
-  cat("SORT CASES by Imputation_.\n", file = codefile, append = TRUE)
-  cat("SPLIT FILE layered by Imputation_.\n", file = codefile, append = TRUE)
 }

--- a/R/mids2spss.R
+++ b/R/mids2spss.R
@@ -47,6 +47,7 @@
 mids2spss <- function(imp, filename="midsdata",
                       path=getwd(), compress = FALSE, silent=FALSE) {
   .id <- NULL # avoid empty global variable binding
+  install.on.demand("haven")
   #extract a completed dataset (long format - all imputations stacked)
   #rename the .imp variable to imputation_, such that SPSS can identify a multiply imputed dataset
   out <-

--- a/man/mids2spss.Rd
+++ b/man/mids2spss.Rd
@@ -6,11 +6,9 @@
 \usage{
 mids2spss(
   imp,
-  filedat = "midsdata.txt",
-  filesps = "readmids.sps",
+  filename = "midsdata",
   path = getwd(),
-  sep = "\\t",
-  dec = ".",
+  compress = FALSE,
   silent = FALSE
 )
 }
@@ -18,22 +16,18 @@ mids2spss(
 \item{imp}{The \code{imp} argument is an object of class \code{mids},
 typically produced by the \code{mice()} function.}
 
-\item{filedat}{A character string describing the name of the output data
-file.}
-
-\item{filesps}{A character string describing the name of the output syntax
-file.}
+\item{filename}{A character string describing the name of the output data
+file and its extension.}
 
 \item{path}{A character string containing the path of the output file. The
-value in \code{path} is appended to \code{filedat} and \code{filesps}. By
+value in \code{path} is appended to \code{filedat}. By
 default, files are written to the current \code{R} working directory. If
 \code{path=NULL} then no file path appending is done.}
 
-\item{sep}{The separator between the data fields.}
+\item{compress}{A logical flag stating whether the resulting SPSS set should 
+be a compressed \code{.zsav} file.}
 
-\item{dec}{The decimal separator for numerical data.}
-
-\item{silent}{A logical flag stating whether the names of the files should be
+\item{silent}{A logical flag stating whether the location of the saved file should be
 printed.}
 }
 \value{
@@ -45,11 +39,8 @@ the data and the SPSS syntax files.
 }
 \details{
 This function automates most of the work needed to export a \code{mids}
-object to SPSS. It uses a modified version of \code{writeForeignSPSS()} from
-the \code{foreign} package. The modified version allows for a choice of the
-field and decimal separators, and makes some improvements to the formatting,
-so that the generated syntax file is amenable to the \code{INCLUDE} statement
-in SPSS.
+object to SPSS. It uses \code{haven::write_sav()} to facilitate the export to an 
+SPSS \code{.sav} or \code{.zsav} file. 
 
 Below are some things to pay attention to.
 
@@ -62,22 +53,19 @@ Factors in \code{R} translate into categorical variables in \code{SPSS}. The
 internal coding of factor levels used in \code{R} is exported. This is
 generally acceptable for \code{SPSS}. However, when the data are to be
 combined with existing \code{SPSS} data, watch out for any changes in the
-factor levels codes. The \code{read.spss()} in package \code{foreign} for
-reading \code{.sav} uses its own internal numbering scheme \code{1,2,3,...}
-for the levels of a factor. Consequently, changes in factor code can cause
-discrepancies in factor level when re-imported to \code{SPSS}. The solution
-is to manually recode the factor level in \code{SPSS}.
+factor levels codes. 
 
 \code{SPSS} will recognize the data set as a multiply imputed data set, and
 do automatic pooling in procedures where that is supported. Note however that
 pooling is an extra option only available to those who license the
 \code{MISSING VALUES} module. Without this license, \code{SPSS} will still
-recognize the structure of the data, but not do any pooling.
+recognize the structure of the data, but it will not pool the multiply imputed 
+estimates into a single inference.
 }
 \seealso{
 \code{\link[=mids-class]{mids}}
 }
 \author{
-Stef van Buuren, dec 2010.
+Gerko Vink, dec 2020.
 }
 \keyword{manip}


### PR DESCRIPTION
This PR would add the following:

- [x] New `mids2spss()` function that replaces the old `mids2spss()` generates one of the following:

  - a `.sav` data set that can be treated as a multiple imputed data set in SPSS
  - a `.zsav` compressed data set that can be treated as a multiple imputed data set in SPSS

- [x] Faster processing, both in `mice` and in SPSS
- [x] The new function deprecates `miceWriteForeignSPSS()`
- [x] Dependency `haven` is added to facilitate im/exporting data sets. This would make it more straightforward to facilitate the export of `mice` objects` to SPSS, SAS and Stata. It does add a dependency, though.
