### PR TITLE
Move call to par() to render second md.pattern() call correctly

### DIFF
--- a/R/md.pattern.R
+++ b/R/md.pattern.R
@@ -72,6 +72,8 @@ md.pattern <- function(x, plot = TRUE, rotate.names = FALSE) {
   r <- cbind(abs(mpat - 1), rowSums(mpat))
   r <- rbind(r, c(nmis[order(nmis)], sum(nmis)))
   if (plot) {
+    op <- par(mar = rep(0, 4))
+    on.exit(par(op))
     plot.new()
     if (is.null(dim(sortR[!duplicated(sortR), ]))) {
       R <- t(as.matrix(r[1:nrow(r) - 1, 1:ncol(r) - 1]))
@@ -81,8 +83,6 @@ md.pattern <- function(x, plot = TRUE, rotate.names = FALSE) {
       }
       R <- r[1:nrow(r) - 1, 1:ncol(r) - 1]
     }
-    op <- par(mar = rep(0, 4))
-    on.exit(par(op))
     if (rotate.names) {
       adj <- c(0, 0.5)
       srt <- 90


### PR DESCRIPTION
Addresses issue #318 , which reports that the second call to `md.pattern()` is cropped. 

### Cause

The issue seems to arrive from the resetting of the plot margins in [line 84](https://github.com/amices/mice/blob/d1386395febd3a0fe54d9fdfa0aa6338cde5c94f/R/md.pattern.R#L84). An old post [here](https://stat.ethz.ch/pipermail/r-help/2005-July/074871.html) seems to suggest that margins need to be set before the call to `plot.new()`.

### Solution

Moving the setting of the margins before `plot.new()` as suggested appears to fix this problem. 

Other plots before and after one or more calls to `md.pattern()` (such as `plot(mtcars)` or `plot(imp)`) also seem to render as expected after the proposed change, suggesting that the change does not introduce unintended side effect.s