### PR TITLE
Fix intercept in `make.formulas()`

### DIFF
--- a/R/formula.R
+++ b/R/formula.R
@@ -39,9 +39,12 @@ make.formulas <- function(data, blocks = make.blocks(data),
       predictors <- names(type)[type != 0]
     }
     x <- setdiff(predictors, y)
+    if (length(x) == 0) {
+      x <- "0"
+    }
     formulas[[h]] <- paste(
       paste(y, collapse = "+"), "~",
-      paste(c("0", x), collapse = "+")
+      paste(x, collapse = "+")
     )
   }
 


### PR DESCRIPTION
#305 describes a difference between predictorMatrix and formula interfaces when using `make.formulas()`.

### Cause

`make.formulas()` adds `0 +` to any formula, therefore already removing the intercept which is then again removed from the design matrix in `sampler.univ()`. As a result, `sampler.univ()` does not in fact remove the intercept but the first predictor variable.

`0` in `make.formulas()` seems to have been added to always provide a valid formula if all entries in a row of the predictorMatrix are 0, e.g. turning the otherwise invalid formula `y ~` into `y ~ 0`

### Solution

Only add `0` if the variable should not be imputed (i.e., the entire row of the predictorMatrix is 0).