### PR TITLE
Add ranger backend for `mice.impute.rf`

### DIFF
--- a/R/mice.impute.rf.R
+++ b/R/mice.impute.rf.R
@@ -55,7 +55,7 @@
 #' plot(imp)
 #' @export
 mice.impute.rf <- function(y, ry, x, wy = NULL, ntree = 10, 
-                           rfPackage = c("randomForest", "ranger"), ...) {
+                           rfPackage = c("ranger", "randomForest"), ...) {
   rfPackage = match.arg(rfPackage)
   
   if (is.null(wy)) wy <- !ry

--- a/R/mice.impute.rf.R
+++ b/R/mice.impute.rf.R
@@ -6,9 +6,9 @@
 #' @inheritParams mice.impute.pmm
 #' @param ntree The number of trees to grow. The default is 10.
 #' @param rfPackage A single string specifying the backend for estimating the 
-#' random forest. The default backend is the \code{randomForest} package (for 
-#' backwards compatibility). The only alternative currently implemented is the 
-#' \code{ranger} package, which has been found to be faster.
+#' random forest. The default backend is the \code{ranger} package. The only 
+#' alternative currently implemented is the \code{randomForest} package, which 
+#' used to be the default in mice 3.13.0 and earlier.
 #' @param \dots Other named arguments passed down to
 #' \code{mice:::install.on.demand()}, \code{randomForest::randomForest()} and
 #' \code{randomForest:::randomForest.default()}.

--- a/man/mice.impute.rf.Rd
+++ b/man/mice.impute.rf.Rd
@@ -4,7 +4,15 @@
 \alias{mice.impute.rf}
 \title{Imputation by random forests}
 \usage{
-mice.impute.rf(y, ry, x, wy = NULL, ntree = 10, ...)
+mice.impute.rf(
+  y,
+  ry,
+  x,
+  wy = NULL,
+  ntree = 10,
+  rfPackage = c("ranger", "randomForest"),
+  ...
+)
 }
 \arguments{
 \item{y}{Vector to be imputed}
@@ -21,6 +29,11 @@ model is fitted. The \code{ry} generally distinguishes the observed
 indicates locations in \code{y} for which imputations are created.}
 
 \item{ntree}{The number of trees to grow. The default is 10.}
+
+\item{rfPackage}{A single string specifying the backend for estimating the 
+random forest. The default backend is the \code{ranger} package. The only 
+alternative currently implemented is the \code{randomForest} package, which 
+used to be the default in mice 3.13.0 and earlier.}
 
 \item{\dots}{Other named arguments passed down to
 \code{mice:::install.on.demand()}, \code{randomForest::randomForest()} and
@@ -73,6 +86,7 @@ Chapman & Hall/CRC. Boca Raton, FL.
 \seealso{
 \code{\link{mice}}, \code{\link{mice.impute.cart}},
 \code{\link[randomForest]{randomForest}}
+\code{\link[ranger]{ranger}}
 
 Other univariate imputation functions: 
 \code{\link{mice.impute.cart}()},


### PR DESCRIPTION
### Changes
As described in #264 , add a `ranger` backend for imputation via random forest. New implementation has been checked using the same tasks used in:

Doove, L. L., S. Van Buuren, and E. Dusseldorp. 2014. “Recursive Partitioning for Missing Data Imputation in the Presence of Interaction Effects.” Computational Statistics & Data Analysis 72: 92–104. 

#### Comment
Since both the `randomForest` package (current default) and the `ranger` package fit the same model class and draw from it in the same way, I have opted to make the choice of backend a new parameter `rfPackage` in `mice.impute.rf`, which keeps `randomForest` as the default choice for backwards compatibility. If this is not wanted, the same implementation can easily be pulled out into its own `mice.impute.ranger`.