### PR TITLE
Ensure correct number of dimensions for ranger

### DIFF
--- a/R/mice.impute.rf.R
+++ b/R/mice.impute.rf.R
@@ -113,8 +113,8 @@ mice.impute.rf <- function(y, ry, x, wy = NULL, ntree = 10,
     type = "terminalNodes", predict.all = TRUE
   )
   nodes <- ranger::predictions(nodes)
-  nodes_obs <- nodes[1:nrow(xobs), ]
-  nodes_mis <- nodes[(nrow(xobs) + 1):nrow(nodes), ]
+  nodes_obs <- nodes[1:nrow(xobs), , drop = FALSE]
+  nodes_mis <- nodes[(nrow(xobs) + 1):nrow(nodes), , drop = FALSE]
 
   select_donors <- function(i) {
     # Function to extract all eligible donors for each missing value

--- a/tests/testthat/test-mice.impute.rf.R
+++ b/tests/testthat/test-mice.impute.rf.R
@@ -1,0 +1,22 @@
+context("mice.impute.rf")
+
+#####################################
+# TEST 1: runs with single miss val #
+#####################################
+
+data <- matrix(c(1.0, 10.5, 1.5, 13.2, 1.8, 8.0, 1.7, 15.0, 23.0, 40.0,
+                 2.0, 21.0, 3.3, 38.0, 4.5, -2.3, NA, -2.4),
+               nrow = 9, ncol = 2, byrow = TRUE)
+df <- data.frame(data)
+
+par <- list(
+  y = df$X1, 
+  ry = !is.na(df$X1), 
+  x = df[, "X2", drop = FALSE]
+)
+
+test_that(
+  "Runs with a single missing value", {
+  expect_visible(do.call(mice.impute.rf, c(par, list(rfPackage = "ranger"))))
+  expect_visible(do.call(mice.impute.rf, c(par, list(rfPackage = "randomForest"))))
+})


### PR DESCRIPTION
### Problem

The current implementation of `mice.impute.rf` drops dimensions (i.e., implicitly converts a matrix to a vector) when only a single value is observed and/or missing for a variable. See #447 for a description of the problem and a reproducible example with `mice` version 3.14.0.

### Solution

Add `, drop = FALSE` to the subsetting to ensure that dimensions aren't dropped. 