### PR TITLE
adapt prop, patterns and weights matrices for pattern with only 1's, and adding warnings when patterns cannot be generated (#449, #317)

### DIFF
--- a/R/ampute.R
+++ b/R/ampute.R
@@ -397,6 +397,13 @@ ampute <- function(data, prop = 0.5, patterns = NULL, freq = NULL,
       n = nrow(patterns.new), size = nrow(data),
       replace = TRUE, prob = freq
     ) + 1
+    
+    # Check whether cases are assigned to all patterns
+    non.used.patterns <- c(2:(nrow(patterns.new)+1))[!c(2:(nrow(patterns.new)+1)) %in% unique(P)]
+    if (length(non.used.patterns) > 0){
+      warning(paste0("No records are assigned to patterns ", toString(non.used.patterns - 1), ". These patterns will not be generated. Consider reducing the number of patterns or increasing the dataset size."), call. = FALSE)
+    }
+    
     # Calculate missingness according MCAR or calculate weighted sum scores
     # Standardized data is used to calculate weighted sum scores
     if (mech == "MCAR") {
@@ -475,7 +482,7 @@ sum.scores <- function(P, data, std, weights, patterns) {
   weights <- as.matrix(weights)
   f <- function(i) {
     if (length(P[P == (i + 1)]) == 0) {
-      return(0)
+      return(0) # this will ensure length 1 which is used in ampute.continuous
     } else {
       candidates <- as.matrix(data[P == (i + 1), ])
       # For each candidate in the pattern, a weighted sum score is calculated

--- a/R/ampute.R
+++ b/R/ampute.R
@@ -269,7 +269,8 @@ ampute <- function(data, prop = 0.5, patterns = NULL, freq = NULL,
       prop = prop,
       freq = freq,
       patterns = patterns.new,
-      n = ncol(data)
+      k = ncol(data),
+      n = nrow(data)
     )
   }
   
@@ -511,8 +512,8 @@ sum.scores <- function(P, data, std, weights, patterns) {
 # This is an underlying function of multivariate amputation function ampute().
 # The function recalculates the proportion of missing cases for the desired
 # #missing cells.
-recalculate.prop <- function(prop, n, patterns, freq) {
-  miss <- prop * n^2 # Desired #missing cells
+recalculate.prop <- function(prop, n, k, patterns, freq) {
+  miss <- prop * n * k # Desired #missing cells
   # Calculate #cases according prop and #zeros in patterns
   cases <- vapply(
     seq_len(nrow(patterns)),

--- a/R/ampute.R
+++ b/R/ampute.R
@@ -229,7 +229,7 @@ ampute <- function(data, prop = 0.5, patterns = NULL, freq = NULL,
   if (is.null(patterns)) {
     patterns <- ampute.default.patterns(n = ncol(data))
   } else if (is.vector(patterns) && (length(patterns) / ncol(data)) %% 1 == 0) {
-    patterns <- matrix(patterns, length(patterns) / ncol(data), byrow = TRUE)
+    patterns <- matrix(patterns, nrow = length(patterns) / ncol(data), byrow = TRUE)
     if (nrow(patterns) == 1 && all(patterns[1, ] %in% 1)) {
       stop("One pattern with merely ones results to no amputation at all, the procedure is therefore stopped", call. = FALSE)
     }
@@ -299,7 +299,7 @@ ampute <- function(data, prop = 0.5, patterns = NULL, freq = NULL,
   }
   if (mech != "MCAR" && !is.null(weights)) {
     if (is.vector(weights) && (length(weights) / ncol(data)) %% 1 == 0) {
-      weights <- matrix(weights, length(weights) / ncol(data), byrow = TRUE)
+      weights <- matrix(weights, nrow = length(weights) / ncol(data), byrow = TRUE)
     } else if (is.vector(weights)) {
       stop("Length of weight vector does not match #variables", call. = FALSE)
     } else if (!is.matrix(weights) && !is.data.frame(weights)) {
@@ -311,11 +311,18 @@ ampute <- function(data, prop = 0.5, patterns = NULL, freq = NULL,
       patterns = patterns.new,
       mech = mech
     )
-  }
+  } 
   weights <- as.data.frame(weights)
-  if (!nrow(weights) %in% c(nrow(patterns), nrow(patterns.new))) {
+  if (!nrow(weights) == nrow(patterns.new)){
+    if (!is.null(check.pat[['row.one']])){
+      weights <- weights[-check.pat[['row.one']],]
+    }
+  }
+  if (!nrow(weights) == nrow(patterns.new)){
     stop("The objects patterns and weights are not matching", call. = FALSE)
   }
+  
+  
   if (!is.vector(cont)) {
     cont <- as.vector(cont)
     warning("Continuous should contain merely TRUE or FALSE", call. = FALSE)
@@ -539,8 +546,8 @@ check.patterns <- function(patterns, freq, prop) {
     }
   }
   if (prop.one != 0) {
-    warning(paste("Proportion of missingness has changed from", prop, "to", prop.one, "because of pattern(s) with merely ones"), call. = FALSE)
-    prop <- prop.one
+    warning(paste("Proportion of missingness has changed from", prop, "to", (1-prop.one)*prop, "because of pattern(s) with merely ones"), call. = FALSE)
+    prop <- (1-prop.one)*prop
     freq <- freq[-row.one]
     freq <- recalculate.freq(freq)
     patterns <- patterns[-row.one, ]
@@ -558,6 +565,7 @@ check.patterns <- function(patterns, freq, prop) {
     patterns = patterns,
     prop = prop,
     freq = freq,
+    row.one = row.one,
     row.zero = row.zero
   )
   objects

--- a/R/ampute.R
+++ b/R/ampute.R
@@ -255,14 +255,6 @@ ampute <- function(data, prop = 0.5, patterns = NULL, freq = NULL,
   if (sum(freq) != 1) {
     freq <- recalculate.freq(freq = freq)
   }
-  if (!bycases) {
-    prop <- recalculate.prop(
-      prop = prop,
-      freq = freq,
-      patterns = patterns,
-      n = ncol(data)
-    )
-  }
   check.pat <- check.patterns(
     patterns = patterns,
     freq = freq,
@@ -271,6 +263,16 @@ ampute <- function(data, prop = 0.5, patterns = NULL, freq = NULL,
   patterns.new <- check.pat[["patterns"]]
   freq <- check.pat[["freq"]]
   prop <- check.pat[["prop"]]
+  
+  if (!bycases) {
+    prop <- recalculate.prop(
+      prop = prop,
+      freq = freq,
+      patterns = patterns.new,
+      n = ncol(data)
+    )
+  }
+  
   if (any(!mech %in% c("MCAR", "MAR", "MNAR"))) {
     stop("Mechanism should be either MCAR, MAR or MNAR", call. = FALSE)
   }

--- a/R/ampute.continuous.R
+++ b/R/ampute.continuous.R
@@ -59,19 +59,22 @@ ampute.continuous <- function(P, scores, prop, type) {
       shift <- shift[1]
     }
     scores.temp <- scores[[i]]
+    # empty candidate group
     if (length(scores.temp) == 1 && scores.temp == 0) {
-      R[[i]] <- 0
+      R[[i]] <- 0 
     } else {
       if (length(scores.temp) == 1) {
+        warning(paste("There is only 1 candidate for pattern", i, ",it will be amputed with probability", prop), call. = FALSE)
         probs <- prop
       } else if (length(unique(scores.temp)) == 1) {
+        warning(paste("The weighted sum scores of all candidates in pattern", i, "are the same, they will be amputed with probability", prop), call. = FALSE)
         probs <- prop
       } else {
         probs <- formula(x = scores.temp, b = shift)
       }
 
       # Based on the probabilities, each candidate will receive a missing data
-      # indicator 0, meaning he will be made missing or missing data indicator 1,
+      # indicator 0, meaning it will be made missing or missing data indicator 1,
       # meaning the candidate will remain complete.
 
       R.temp <- 1 - rbinom(n = length(scores.temp), size = 1, prob = probs)

--- a/tests/testthat/test-ampute.R
+++ b/tests/testthat/test-ampute.R
@@ -268,6 +268,96 @@ test_that("error messages work properly", {
   )
 })
 
+# extra tests for dimensions patterns and weights matrix (#449)
+
+test_that("patterns and weights matrices have right dimensions", {
+  
+  suppressWarnings(
+    expect_true(all(
+      ampute(data = complete.data, patterns = c(1, 1, 1, 0, 1, 0))$patterns == c(0, 1, 0)
+    ))
+  )
+  
+  suppressWarnings(
+  expect_true(all(
+      ampute(data = complete.data, patterns = c(0, 1, 0, 1, 1, 1))$patterns == c(0, 1, 0)
+    ))
+  )
+  
+  suppressWarnings(
+    expect_true(all(
+      ampute(data = complete.data, patterns = c(1, 1, 1, 0, 1, 0, 1, 1, 1))$patterns == c(0, 1, 0)
+    ))
+  )
+  
+  suppressWarnings(
+    expect_true(all(
+      ampute(data = complete.data, patterns = c(1, 1, 1, 0, 1, 0),
+            weights = c(1, 0, 0, 0, 1, 0))$weights == c(0, 1, 0)
+    ))
+  )
+  
+  suppressWarnings(
+    expect_true(all(
+      ampute(data = complete.data, patterns = c(0, 1, 0, 1, 1, 1),
+            weights = c(1, 0, 0, 0, 1, 0))$weights == c(1, 0, 0)
+    ))
+  )
+  
+  suppressWarnings(
+    expect_true(all(
+      ampute(data = complete.data, patterns = c(0, 1, 0, 1, 1, 1),
+            weights = c(1, 0, 0))$weights == c(1, 0, 0)
+    ))
+  )
+  
+  suppressWarnings(
+    expect_true(all(
+      ampute(data = complete.data, patterns = c(1, 1, 1, 0, 1, 0, 1, 1, 1),
+            weights = c(1, 0, 0))$weights == c(1, 0, 0)
+    ))
+  )
+  
+  suppressWarnings(
+    expect_true(all(
+      ampute(data = complete.data, patterns = c(1, 1, 1, 0, 1, 0, 1, 1, 1),
+            weights = c(1, 0, 0, 0, 1, 0, 0, 0, 1))$weights == c(0, 1, 0)
+    ))
+  )
+  
+})
+
+test_that("prop and freq are properly adjusted when patterns contain only 1's", {
+  
+  suppressWarnings(
+    expect_equal(ampute(data = complete.data, patterns = c(1, 1, 1, 0, 1, 0))$prop, 0.25)
+  )
+  
+  suppressWarnings(
+    expect_equal(ampute(data = complete.data, patterns = c(1, 1, 1, 0, 1, 0))$freq, 1)
+  )
+  
+  suppressWarnings(
+    expect_equal(
+      ampute(data = complete.data, patterns = c(1, 1, 1, 0, 1, 0, 0, 1, 0))$prop, 1/3)
+  )
+  
+  suppressWarnings(
+    expect_true(all(
+      ampute(data = complete.data, patterns = c(1, 1, 1, 0, 1, 0, 0, 1, 0))$freq == c(0.5, 0.5)))
+  )
+  
+  suppressWarnings(
+    expect_equal(
+      ampute(data = complete.data, patterns = c(1, 1, 1, 0, 1, 0, 1, 1, 1))$prop, 1/3*0.5)
+  )
+  
+  suppressWarnings(
+    expect_equal(
+      ampute(data = complete.data, patterns = c(1, 1, 1, 0, 1, 0, 1, 1, 1))$freq, 1)
+  )
+    
+})
 
 # The following test was contributed by Shangzhi-hong (#216) Dec 2019
 context("ampute robust version")

--- a/tests/testthat/test-ampute.R
+++ b/tests/testthat/test-ampute.R
@@ -268,7 +268,7 @@ test_that("error messages work properly", {
   )
 })
 
-# extra tests for dimensions patterns and weights matrix (#449)
+# The following tests were created to evaluate the patterns and weights matrices in case of a pattern with only 1's (#449)
 
 test_that("patterns and weights matrices have right dimensions", {
   
@@ -359,6 +359,32 @@ test_that("prop and freq are properly adjusted when patterns contain only 1's", 
     
 })
 
+# The following test was created to evaluate warnings when not all patterns can be generated (#317)
+
+test_that("warnings appear when not all patterns can be generated", {
+  
+  set.seed(12032021)
+  binary.data <- lapply(
+    runif(10, 0.05, 0.15),
+    function(p, n) rbinom(n, 1, p),
+    n = 10
+  ) %>%
+    do.call(what = "data.frame") %>%
+    set_names(paste0("type", LETTERS[1:ncol(.)]))
+  expect_warning(
+    ampute(
+      data = binary.data
+    )
+  )
+  
+  df <- matrix(c(runif(1000, 0.5, 1), rep(0, 1000)), nrow = 1000, byrow = FALSE)
+  expect_warning(
+    ampute(df, pattern = c(0, 1)),
+    "The weighted sum scores of all candidates in pattern 1 are the same, they will be amputed with probability 0.5"
+    )
+})
+  
+
 # The following test was contributed by Shangzhi-hong (#216) Dec 2019
 context("ampute robust version")
 
@@ -406,15 +432,17 @@ bycases <- TRUE
 # run <- TRUE
 
 test_that("ampute() works under extreme condition", {
-  ampDf <- ampute(
-    data = data,
-    prop = prop,
-    mech = mech,
-    type = type,
-    bycases = bycases,
-    patterns = patterns,
-    weights = weights
-  )$amp
+  expect_warning(
+    ampDf <- ampute(
+      data = data,
+      prop = prop,
+      mech = mech,
+      type = type,
+      bycases = bycases,
+      patterns = patterns,
+      weights = weights
+    )$amp
+  )
   outProp <- sum(complete.cases(ampDf)) / NUM_OBS_DF
   expect_true(outProp > 0.3 & outProp < 0.7)
 })

--- a/tests/testthat/test-ampute.R
+++ b/tests/testthat/test-ampute.R
@@ -370,7 +370,7 @@ test_that("warnings appear when not all patterns can be generated", {
     n = 10
   ) %>%
     do.call(what = "data.frame") %>%
-    set_names(paste0("type", LETTERS[1:ncol(.)]))
+    rlang::set_names(paste0("type", LETTERS[1:ncol(.)]))
   expect_warning(
     ampute(
       data = binary.data


### PR DESCRIPTION
Dear Stef, dear Gerko,

I have made adjustments in ampute() regarding the calculation of prop, patterns and weights in the situation that a user specifies a pattern with only 1s (issue #449). I have furthermore added unittests and evaluated that all other tests work.

Can you accept my pull request?

Thank you,
Rianne