### PR TITLE
Minor edit to `convergence()` for usability

### DIFF
--- a/R/convergence.R
+++ b/R/convergence.R
@@ -84,7 +84,7 @@ convergence <- function(data, diagnostic = "all", parameter = "mean", ...) {
     ac <-
       purrr::map_dfr(vrbs, function(.vrb) {
         base::rbind(NA, NA, purrr::map_dfr(3:t, function(.itr) {
-          data.frame(ac = max(purrr::map_dbl(1:m, function(.imp) {
+          data.frame(ac = max_or_NA(purrr::map_dbl(1:m, function(.imp) {
             suppressWarnings(stats::cor(param[[.vrb]][1:.itr - 1, .imp], param[[.vrb]][2:.itr, .imp]))
           })))
         }))
@@ -105,3 +105,11 @@ convergence <- function(data, diagnostic = "all", parameter = "mean", ...) {
   return(out)
 }
 
+# function to calculate the maximum unless all are NA
+max_or_NA <- function(x) {
+  if(all(is.na(x))) {
+    return(NA) 
+  } else {
+    return(max(x, na.rm = TRUE))
+  }
+}

--- a/R/convergence.R
+++ b/R/convergence.R
@@ -30,6 +30,13 @@
 #' \item{\code{"gr"}}{same as \code{psrf}, the potential scale reduction
 #' factor is colloquially called the Gelman-Rubin diagnostic.}
 #' }
+#' In the unlikely event of perfect convergence, the autocorrelation equals
+#' zero and the potential scale reduction factor equals one. To interpret 
+#' the convergence diagnostic(s) in the output of the function, it is 
+#' recommended to plot the diagnostics (ac and/or psrf) against the 
+#' iteration number (.it) per imputed variable (vrb). A persistently 
+#' decreasing trend across iterations indicates potential non-convergence.
+#' 
 #' @seealso \code{\link{mice}}, \code{\link[=mids-class]{mids}}
 #' @keywords none
 #' @references Vehtari, A., Gelman, A., Simpson, D., Carpenter, B., & Burkner, 
@@ -49,6 +56,10 @@ convergence <- function(data, diagnostic = "all", parameter = "mean", ...) {
   install.on.demand("purrr", ...)
   if (!is.mids(data))
     stop("'data' not of class 'mids'")
+  if (data$m < 2)
+    stop("the number of imputations should be at least two (m > 1)")
+  if (data$iteration < 3)
+    stop("the number of iterations should be at least three (maxit > 2)")
   if (is.null(data$chainMean)) 
     stop("no convergence diagnostics found", call. = FALSE)
   if (parameter != "mean" & parameter != "sd")

--- a/man/convergence.Rd
+++ b/man/convergence.Rd
@@ -44,6 +44,12 @@ per iteration;}
 \item{\code{"gr"}}{same as \code{psrf}, the potential scale reduction
 factor is colloquially called the Gelman-Rubin diagnostic.}
 }
+In the unlikely event of perfect convergence, the autocorrelation equals
+zero and the potential scale reduction factor equals one. To interpret 
+the convergence diagnostic(s) in the output of the function, it is 
+recommended to plot the diagnostics (ac and/or psrf) against the 
+iteration number (.it) per imputed variable (vrb). A persistently 
+decreasing trend across iterations indicates potential non-convergence.
 }
 \examples{
 


### PR DESCRIPTION
Added error messages for the number of imputations and the number of iterations in the `mids` object (should be > 1 and > 2, respectively). And added an interpretation paragraph to the documentation under Details.