### PR TITLE
Fix p-value calculation to use lower.tail

### DIFF
--- a/R/D3.R
+++ b/R/D3.R
@@ -115,7 +115,7 @@ D3 <- function(fit1, fit0 = NULL, dfcom = NULL, df.com = NULL) {
   } else {
     w <- v * (1 + 1 / k) * ((1 + 1 / rm)^2) / 2
   }
-  pvalue <- 1 - pf(Dm, k, w)
+  pvalue <- pf(Dm, k, w, lower.tail = FALSE)
 
   test <-
     out <- list(

--- a/R/mcar.R
+++ b/R/mcar.R
@@ -330,7 +330,7 @@ hawkins <- function(x, grouping){
     i_centered <- i_centered * nrow(i)
     ((n - g - p) * i_centered)/(p * ((nrow(i) - 1) * (n - g) - i_centered))
   })
-  a <- lapply(f, function(thisf){ 1 - pf(thisf, p, (n-g - p)) })
+  a <- lapply(f, function(thisf){ pf(thisf, p, (n-g - p), lower.tail = FALSE) })
   list(fij = f, a = a, ni = matrix(sapply(x, nrow), ncol = 1))
 }
 

--- a/R/mipo.R
+++ b/R/mipo.R
@@ -68,7 +68,7 @@ summary.mipo <- function(object, type = c("tests", "all"),
   x <- object$pooled
   std.error <- sqrt(x$t)
   statistic <- x$estimate / std.error
-  p.value <- 2 * (1 - pt(abs(statistic), pmax(x$df, 0.001)))
+  p.value <- 2 * (pt(abs(statistic), pmax(x$df, 0.001), lower.tail = FALSE))
 
   z <- data.frame(x,
     std.error = std.error,

--- a/R/pool.compare.R
+++ b/R/pool.compare.R
@@ -172,7 +172,7 @@ pool.compare <- function(fit1, fit0, method = c("wald", "likelihood"),
     ubar1 = est1$pooled$ubar, ubar0 = est0$pooled$ubar,
     deviances = deviances,
     Dm = Dm, rm = rm, df1 = dimQ2, df2 = w,
-    pvalue = 1 - pf(Dm, dimQ2, w)
+    pvalue = pf(Dm, dimQ2, w, lower.tail = FALSE)
   )
   statistic
 }


### PR DESCRIPTION
lower.tail=FALSE instead of the complement increases numerical precision for very small p-values. See #487 
