### PR TITLE
Add support for models reporting contrasts rather than terms

### DIFF
--- a/R/pool.R
+++ b/R/pool.R
@@ -166,11 +166,12 @@ pool.fitlist <- function(fitlist, dfcom = NULL,
   rule <- match.arg(rule)
 
   w <- summary(fitlist, type = "tidy", exponentiate = FALSE)
-  grp <- intersect(names(w), c("parameter", "term", "y.level", "component"))
+  grp <- intersect(names(w), c("parameter", "term", "contrast", "y.level", "component"))
 
   # Note: group_by() changes the order of the terms, which is undesirable
   # We convert any parameter terms to factor to preserve ordering
   if ("term" %in% names(w)) w$term <- factor(w$term, levels = unique(w$term))
+  if ("contrast" %in% names(w)) w$contrast <- factor(w$contrast, levels = unique(w$contrast))
   if ("y.level" %in% names(w)) w$y.level <- factor(w$y.level, levels = unique(w$y.level))
   if ("component" %in% names(w)) w$component <- factor(w$component, levels = unique(w$component))
 

--- a/R/tidiers.R
+++ b/R/tidiers.R
@@ -41,8 +41,6 @@ tidy.mipo <- function(x, conf.int = FALSE, conf.level = .95, ...) {
   if ("term" %in% names(out)) out$term <- as.character(out$term)
   if ("contrast" %in% names(out)) out$contrast <- as.character(out$contrast)
 
-  out$term <- as.character(out$term)
-
   # needed for broom <= 0.5.6
   # rename variables if present
   idx <- grepl("%", names(out))

--- a/R/tidiers.R
+++ b/R/tidiers.R
@@ -37,6 +37,10 @@ tidy.mipo <- function(x, conf.int = FALSE, conf.level = .95, ...) {
     conf.level = conf.level,
     ...
   )
+
+  if ("term" %in% names(out)) out$term <- as.character(out$term)
+  if ("contrast" %in% names(out)) out$contrast <- as.character(out$contrast)
+
   out$term <- as.character(out$term)
 
   # needed for broom <= 0.5.6


### PR DESCRIPTION
To fix #497, I made small edits to `pool.fitlist` and `tidy.mipo` that now accept `contrast` as an alternative to `term` ... before, `tidy.mipo` would just fail without a `term` column. 

Does that make sense to you? 