### PR TITLE
Edit test broken on R<4

### DIFF
--- a/tests/testthat/test-mice.impute.durr.logreg.R
+++ b/tests/testthat/test-mice.impute.durr.logreg.R
@@ -23,7 +23,7 @@ set.seed(123)
 imps <- mice.impute.lasso.logreg(y, ry, x)
 
 test_that("Returns a matrix of dimensionality sum(wy) x 1", {
-  expect_equal(class(imps), c("matrix", "array"))
+  expect_true(is.matrix(imps))
   expect_equal(dim(imps), c(sum(wy), 1))
 })
 


### PR DESCRIPTION
Test assumes behavior new to R4.0.0 (namely, that `class(matrix())` is `c("matrix", "array")`). It's better to use `is.matrix()` instead.