### PR TITLE
use x$lastSeedValue, not .Random.seed (which may not exist)

### DIFF
--- a/R/cbind.R
+++ b/R/cbind.R
@@ -367,7 +367,7 @@ cbind.mids.mids <- function(x, y, call) {
     ignore = ignore,
     seed = seed,
     iteration = iteration,
-    lastSeedValue = .Random.seed,
+    lastSeedValue = x$lastSeedValue,
     chainMean = chainMean,
     chainVar = chainVar,
     loggedEvents = loggedEvents,


### PR DESCRIPTION
I'm seeing an error where cbind() wounds up run without .Random.seed set, which this solves.

Per `?.Random.seed`, no seed is set initially in the session until the first time `set.seed()` is run:

>      Initially, there is no seed; a new one is created from the current time and the process ID when one is required.

I don't know enough about the package to know if this fix is for sure correct, but I noticed a similar fix applied in the same file:

https://github.com/amices/mice/commit/1189fe10aee92077f05d68279da7974090e86d60