### PR TITLE
add flexible pooling for the total variance of (Q-Qbar)

### DIFF
--- a/R/pool.R
+++ b/R/pool.R
@@ -100,9 +100,11 @@
 #' \code{"rubin1987"} (default, for missing data) and \code{"reiter2003"}
 #' (for synthetic data created from a complete data set).
 #' @param custom.t A custom character string to be parsed as a calculation rule 
-#' for the total variance \code{t}. The custom rule  must use the other calculated 
-#' pooling statistics. The default \code{t} calculation would have the form 
-#' \code{".data$ubar + (1 + 1 / .data$m) * .data$b"}. See examples for an example.
+#' for the total variance \code{t}. The custom rule  can use the other calculated 
+#' pooling statistics where the dimensions must come from \code{.data$}. The 
+#' default \code{t} calculation would have the form 
+#' \code{".data$ubar + (1 + 1 / .data$m) * .data$b"}. 
+#' See examples for an example.
 #' @return An object of class \code{mipo}, which stands for 'multiple imputation
 #' pooled outcome'.
 #' For rule \code{"reiter2003"} values for \code{lambda} and \code{fmi} are

--- a/R/pool.R
+++ b/R/pool.R
@@ -99,6 +99,10 @@
 #' @param rule A string indicating the pooling rule. Currently supported are
 #' \code{"rubin1987"} (default, for missing data) and \code{"reiter2003"}
 #' (for synthetic data created from a complete data set).
+#' @param custom.t A custom character string to be parsed as a calculation rule 
+#' for the total variance \code{t}. The custom rule  must use the other calculated 
+#' pooling statistics. The default \code{t} calculation would have the form 
+#' \code{".data$ubar + (1 + 1 / .data$m) * .data$b"}. See examples for an example.
 #' @return An object of class \code{mipo}, which stands for 'multiple imputation
 #' pooled outcome'.
 #' For rule \code{"reiter2003"} values for \code{lambda} and \code{fmi} are
@@ -132,8 +136,15 @@
 #'             where = matrix(TRUE, nrow(cars), ncol(cars)))
 #' fit <- with(data = imp, exp = lm(speed ~ dist))
 #' summary(pool.syn(fit))
+#' 
+#' # use a custom pooling rule for the total variance about the estimate
+#' # e.g. use t = b + b/m instead of t = ubar + b + b/m
+#' imp <- mice(nhanes, maxit = 2, m = 2)
+#' fit <- with(data = imp, exp = lm(bmi ~ hyp + chl))
+#' pool(fit, custom.t = ".data$b + .data$b / .data$m")
+#' 
 #' @export
-pool <- function(object, dfcom = NULL, rule = NULL) {
+pool <- function(object, dfcom = NULL, rule = NULL, custom.t = NULL) {
   call <- match.call()
 
   if (!is.list(object)) stop("Argument 'object' not a list", call. = FALSE)
@@ -146,7 +157,7 @@ pool <- function(object, dfcom = NULL, rule = NULL) {
   }
 
   dfcom <- get.dfcom(object, dfcom)
-  pooled <- pool.fitlist(getfit(object), dfcom = dfcom, rule = rule)
+  pooled <- pool.fitlist(getfit(object), dfcom = dfcom, rule = rule, custom.t = custom.t)
 
   # mipo object
   rr <- list(
@@ -159,7 +170,7 @@ pool <- function(object, dfcom = NULL, rule = NULL) {
 }
 
 pool.fitlist <- function(fitlist, dfcom = NULL,
-                         rule = c("rubin1987", "reiter2003")) {
+                         rule = c("rubin1987", "reiter2003"), custom.t = NULL) {
 
   # rubin1987: Rubin's rules for scalar estimates
   # reiter2003: Reiter's rules for partially synthetic data
@@ -187,7 +198,9 @@ pool.fitlist <- function(fitlist, dfcom = NULL,
         qbar = mean(.data$estimate),
         ubar = mean(.data$std.error^2),
         b = var(.data$estimate),
-        t = .data$ubar + (1 + 1 / .data$m) * .data$b,
+        t = ifelse(is.null(custom.t), 
+                   .data$ubar + (1 + 1 / .data$m) * .data$b, 
+                   eval(parse(text = custom.t))),
         dfcom = dfcom,
         df = barnard.rubin(.data$m, .data$b, .data$t, .data$dfcom),
         riv = (1 + 1 / .data$m) * .data$b / .data$ubar,
@@ -204,7 +217,9 @@ pool.fitlist <- function(fitlist, dfcom = NULL,
         qbar = mean(.data$estimate),
         ubar = mean(.data$std.error^2),
         b = var(.data$estimate),
-        t = .data$ubar + (1 / .data$m) * .data$b,
+        t = ifelse(is.null(custom.t), 
+                   .data$ubar + (1 / .data$m) * .data$b, 
+                   eval(parse(text = custom.t))),
         dfcom = dfcom,
         df = (.data$m - 1) * (1 + (.data$ubar / (.data$b/.data$m)))^2,
         riv = (1 + 1 / .data$m) * .data$b / .data$ubar,

--- a/man/pool.Rd
+++ b/man/pool.Rd
@@ -5,7 +5,7 @@
 \alias{pool.syn}
 \title{Combine estimates by pooling rules}
 \usage{
-pool(object, dfcom = NULL, rule = NULL)
+pool(object, dfcom = NULL, rule = NULL, custom.t = NULL)
 
 pool.syn(object, dfcom = NULL, rule = "reiter2003")
 }
@@ -28,6 +28,11 @@ manually.}
 \item{rule}{A string indicating the pooling rule. Currently supported are
 \code{"rubin1987"} (default, for missing data) and \code{"reiter2003"}
 (for synthetic data created from a complete data set).}
+
+\item{custom.t}{A custom character string to be parsed as a calculation rule 
+for the total variance \code{t}. The custom rule  must use the other calculated 
+pooling statistics. The default \code{t} calculation would have the form 
+\code{".data$ubar + (1 + 1 / .data$m) * .data$b"}. See examples for an example.}
 }
 \value{
 An object of class \code{mipo}, which stands for 'multiple imputation
@@ -130,6 +135,13 @@ imp <- mice(cars, maxit = 2, m = 2,
             where = matrix(TRUE, nrow(cars), ncol(cars)))
 fit <- with(data = imp, exp = lm(speed ~ dist))
 summary(pool.syn(fit))
+
+# use a custom pooling rule for the total variance about the estimate
+# e.g. use t = b + b/m instead of t = ubar + b + b/m
+imp <- mice(nhanes, maxit = 2, m = 2)
+fit <- with(data = imp, exp = lm(bmi ~ hyp + chl))
+pool(fit, custom.t = ".data$b + .data$b / .data$m")
+
 }
 \references{
 Barnard, J. and Rubin, D.B. (1999). Small sample degrees of

--- a/man/pool.Rd
+++ b/man/pool.Rd
@@ -30,9 +30,11 @@ manually.}
 (for synthetic data created from a complete data set).}
 
 \item{custom.t}{A custom character string to be parsed as a calculation rule 
-for the total variance \code{t}. The custom rule  must use the other calculated 
-pooling statistics. The default \code{t} calculation would have the form 
-\code{".data$ubar + (1 + 1 / .data$m) * .data$b"}. See examples for an example.}
+for the total variance \code{t}. The custom rule  can use the other calculated 
+pooling statistics where the dimensions must come from \code{.data$}. The 
+default \code{t} calculation would have the form 
+\code{".data$ubar + (1 + 1 / .data$m) * .data$b"}. 
+See examples for an example.}
 }
 \value{
 An object of class \code{mipo}, which stands for 'multiple imputation


### PR DESCRIPTION
I had need for a custom total variance calculation, other than $T = \bar{U} + B + B/m$. Have updated `pool()` with argument `custom.t` to accept a custom string for $T$ that takes the following  usage:

``` r
library(mice)
library(magrittr)
set.seed(123)
imp <- mice(nhanes, printFlag = FALSE)
fit <- with(imp, lm(age ~ bmi))

# regular calculation
pool(fit)  %T>% 
  print %>% summary()
#> Class: mipo    m = 5 
#>          term m    estimate        ubar            b           t dfcom       df
#> 1 (Intercept) 5  3.91587204 1.154102714 0.3341192913 1.555045863    23 12.48683
#> 2         bmi 5 -0.08122935 0.001629126 0.0003996515 0.002108708    23 13.53213
#>         riv    lambda       fmi
#> 1 0.3474068 0.2578336 0.3536785
#> 2 0.2943799 0.2274293 0.3208922
#>          term    estimate  std.error statistic       df    p.value
#> 1 (Intercept)  3.91587204 1.24701478  3.140197 12.48683 0.00816489
#> 2         bmi -0.08122935 0.04592067 -1.768906 13.53213 0.09943129

# custom calculation
pool(fit, rule = "reiter2003", custom.t = ".data$b + .data$b/m") %T>% 
  print %>% summary()
#> Class: mipo    m = 5 
#>          term m    estimate        ubar            b            t dfcom
#> 1 (Intercept) 5  3.91587204 1.154102714 0.3341192913 0.4009431496    23
#> 2         bmi 5 -0.08122935 0.001629126 0.0003996515 0.0004795819    23
#>         df       riv lambda fmi
#> 1 1335.291 0.3474068     NA  NA
#> 2 1828.730 0.2943799     NA  NA
#>          term    estimate  std.error statistic       df      p.value
#> 1 (Intercept)  3.91587204 0.63320072  6.184251 1335.291 8.278363e-10
#> 2         bmi -0.08122935 0.02189936 -3.709212 1828.730 2.141111e-04

# another custom calculation
outsideoffunction <- 14
pool(fit, rule = "rubin1987", custom.t = "outsideoffunction")  %T>% 
  print %>% summary()
#> Class: mipo    m = 5 
#>          term m    estimate        ubar            b  t dfcom       df
#> 1 (Intercept) 5  3.91587204 1.154102714 0.3341192913 14    23 20.53591
#> 2         bmi 5 -0.08122935 0.001629126 0.0003996515 14    23 21.22865
#>         riv       lambda       fmi
#> 1 0.3474068 2.863880e-02 0.3209004
#> 2 0.2943799 3.425585e-05 0.2912026
#>          term    estimate std.error   statistic       df   p.value
#> 1 (Intercept)  3.91587204  3.741657  1.04656083 20.53591 0.3074648
#> 2         bmi -0.08122935  3.741657 -0.02170946 21.22865 0.9828825
```

<sup>Created on 2022-11-03 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>