### PR TITLE
Decide which cells to update after post-processing

### DIFF
--- a/R/sampler.R
+++ b/R/sampler.R
@@ -89,7 +89,8 @@ sampler <- function(data, m, ignore, where, imp, blocks, method,
               cmd <- post[j]
               if (cmd != "") {
                 eval(parse(text = cmd))
-                data[(!r[, j]) & where[, j], j] <- imp[[j]][, i]
+                data[where[, j], j] <- imp[[j]][, i]
+                #data[(!r[, j]) & where[, j], j] <- imp[[j]][, i] # POTENTIAL FIX TO SAMPLER
               }
             }
           }


### PR DESCRIPTION
This commit changes the post-processing command in the sampler to its previous state. I still believe we have to discuss this matter, but this fix at least fixes potential backward compatibility issues for now. We can make an informed decision later.