### PR TITLE
Futuremice

### DIFF
--- a/R/futuremice.R
+++ b/R/futuremice.R
@@ -139,12 +139,11 @@ futuremice <- function(data, m = 5, parallelseed = NA, n.core = NULL, seed = NA,
       }
     }
   }
-  if (is.na(parallelseed)) {
-    parallelseed <- round(runif(1, -999999999, 999999999))
+  if (!is.na(parallelseed)) {
+    set.seed(parallelseed)
+  } else {
+    parallelseed <- .Random.seed
   }
-
-  ### set seed, either user-specified or randomly drawn
-  withr::local_seed(parallelseed)
 
   # start multisession
   future::plan(future.plan,

--- a/R/parlmice.R
+++ b/R/parlmice.R
@@ -1,8 +1,7 @@
 #' Wrapper function that runs MICE in parallel
 #'
-#' This is a wrapper function for \code{\link{mice}}, using multiple cores to
-#' execute \code{\link{mice}} in parallel. As a result, the imputation
-#' procedure can be sped up, which may be useful in general.
+#' This function is included for backward compatibility. The function
+#' is superseded by \code{\link{futuremice}}.
 #'
 #' This function relies on package \code{\link{parallel}}, which is a base
 #' package for R versions 2.14.0 and later. We have chosen to use parallel function
@@ -69,6 +68,8 @@
 #' @export
 parlmice <- function(data, m = 5, seed = NA, cluster.seed = NA, n.core = NULL,
                      n.imp.core = NULL, cl.type = "PSOCK", ...) {
+  
+  .Deprecated("futuremice")
   # check form of data and m
   data <- check.dataform(data)
   m <- check.m(m)


### PR DESCRIPTION
Deprecate parlmice and fix seed functionality futuremice. In fact, I believe that this might be a solution for mice itself as well. Storing the state of the random number generator before running the sampler allows the user to always reproduce the imputations.