### PR TITLE
restore futuremice parallelseed to old behaviour

### DIFF
--- a/R/futuremice.R
+++ b/R/futuremice.R
@@ -142,7 +142,7 @@ futuremice <- function(data, m = 5, parallelseed = NA, n.core = NULL, seed = NA,
   if (!is.na(parallelseed)) {
     set.seed(parallelseed)
   } else {
-    parallelseed <- .Random.seed
+    parallelseed <- round(runif(1, -999999999, 999999999))
   }
 
   # start multisession


### PR DESCRIPTION
Closes #517.

Revert back `parrallelseed` behaviour. `.Random.seed` was not found when calling `futuremice()` outside of `.GlobalEnv`. Now this works:

``` r
library(mice, warn.conflicts = FALSE)
ex <- function(x){
  run <- function(x){
    futuremice(x, m=5, n.core=2)
  }
  run(x)
}
ex(nhanes)
#> Class: mids
#> Number of multiple imputations:  5 
#> Imputation methods:
#>   age   bmi   hyp   chl 
#>    "" "pmm" "pmm" "pmm" 
#> PredictorMatrix:
#>     age bmi hyp chl
#> age   0   1   1   1
#> bmi   1   0   1   1
#> hyp   1   1   0   1
#> chl   1   1   1   0

{futuremice(nhanes, n.core=2)}
#> Class: mids
#> Number of multiple imputations:  5 
#> Imputation methods:
#>   age   bmi   hyp   chl 
#>    "" "pmm" "pmm" "pmm" 
#> PredictorMatrix:
#>     age bmi hyp chl
#> age   0   1   1   1
#> bmi   1   0   1   1
#> hyp   1   1   0   1
#> chl   1   1   1   0
```

<sup>Created on 2022-11-10 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Saw no need to use `.Random.seed` from whatever frame as the `mids` object inherits the used `parallelseed`. 