### PR TITLE
update where documentation

### DIFF
--- a/R/mice.R
+++ b/R/mice.R
@@ -164,7 +164,11 @@
 #' as \code{data} indicating where in the data the imputations should be
 #' created. The default, \code{where = is.na(data)}, specifies that the
 #' missing data should be imputed. The \code{where} argument may be used to
-#' overimpute observed data, or to skip imputations for selected missing values.
+#' overimpute observed data, or to skip imputations for selected missing values. 
+#' Note: Imputation methods that generate imptutations outside of 
+#' \code{mice}, like \code{mice.impute.panImpute()} may depend on a complete 
+#' predictor space. In that case, a custom \code{where} matrix can not be 
+#' specified. 
 #' @param blocks List of vectors with variable names per block. List elements
 #' may be named to identify blocks. Variables within a block are
 #' imputed by a multivariate imputation method

--- a/man/as.mids.Rd
+++ b/man/as.mids.Rd
@@ -15,7 +15,11 @@ or by other software.}
 as \code{data} indicating where in the data the imputations should be
 created. The default, \code{where = is.na(data)}, specifies that the
 missing data should be imputed. The \code{where} argument may be used to
-overimpute observed data, or to skip imputations for selected missing values.}
+overimpute observed data, or to skip imputations for selected missing values. 
+Note: Imputation methods that generate imptutations outside of 
+\code{mice}, like \code{mice.impute.panImpute()} may depend on a complete 
+predictor space. In that case, a custom \code{where} matrix can not be 
+specified.}
 
 \item{.imp}{An optional column number or column name in \code{long},
 indicating the imputation index. The values are assumed to be consecutive

--- a/man/make.method.Rd
+++ b/man/make.method.Rd
@@ -19,7 +19,11 @@ values are coded as \code{NA}.}
 as \code{data} indicating where in the data the imputations should be
 created. The default, \code{where = is.na(data)}, specifies that the
 missing data should be imputed. The \code{where} argument may be used to
-overimpute observed data, or to skip imputations for selected missing values.}
+overimpute observed data, or to skip imputations for selected missing values. 
+Note: Imputation methods that generate imptutations outside of 
+\code{mice}, like \code{mice.impute.panImpute()} may depend on a complete 
+predictor space. In that case, a custom \code{where} matrix can not be 
+specified.}
 
 \item{blocks}{List of vectors with variable names per block. List elements
 may be named to identify blocks. Variables within a block are

--- a/man/mice.Rd
+++ b/man/mice.Rd
@@ -65,7 +65,11 @@ or \code{mice.impute.panImpute()}, do not honour the \code{ignore} argument.}
 as \code{data} indicating where in the data the imputations should be
 created. The default, \code{where = is.na(data)}, specifies that the
 missing data should be imputed. The \code{where} argument may be used to
-overimpute observed data, or to skip imputations for selected missing values.}
+overimpute observed data, or to skip imputations for selected missing values. 
+Note: Imputation methods that generate imptutations outside of 
+\code{mice}, like \code{mice.impute.panImpute()} may depend on a complete 
+predictor space. In that case, a custom \code{where} matrix can not be 
+specified.}
 
 \item{blocks}{List of vectors with variable names per block. List elements
 may be named to identify blocks. Variables within a block are

--- a/man/nimp.Rd
+++ b/man/nimp.Rd
@@ -11,7 +11,11 @@ nimp(where, blocks = make.blocks(where))
 as \code{data} indicating where in the data the imputations should be
 created. The default, \code{where = is.na(data)}, specifies that the
 missing data should be imputed. The \code{where} argument may be used to
-overimpute observed data, or to skip imputations for selected missing values.}
+overimpute observed data, or to skip imputations for selected missing values. 
+Note: Imputation methods that generate imptutations outside of 
+\code{mice}, like \code{mice.impute.panImpute()} may depend on a complete 
+predictor space. In that case, a custom \code{where} matrix can not be 
+specified.}
 
 \item{blocks}{List of vectors with variable names per block. List elements
 may be named to identify blocks. Variables within a block are


### PR DESCRIPTION
Added a note to the documentation of the `where` argument to specify that some imputation methods require a complete(d) predictor. Specifying `where` may then break functionality. Closes #520. 