### PR TITLE
Pass extra arguments mice.impute.rf() to ranger::ranger()

### DIFF
--- a/R/mice.impute.rf.R
+++ b/R/mice.impute.rf.R
@@ -10,8 +10,8 @@
 #' alternative currently implemented is the \code{randomForest} package, which
 #' used to be the default in mice 3.13.10 and earlier.
 #' @param \dots Other named arguments passed down to
-#' \code{mice:::install.on.demand()}, \code{randomForest::randomForest()} and
-#' \code{randomForest:::randomForest.default()}.
+#' \code{mice:::install.on.demand()}, \code{randomForest::randomForest()},
+#' \code{randomForest:::randomForest.default()}, and \code{ranger::ranger()}.
 #' @return Vector with imputed data, same type as \code{y}, and of length
 #' \code{sum(wy)}
 #' @details
@@ -106,7 +106,12 @@ mice.impute.rf <- function(y, ry, x, wy = NULL, ntree = 10,
   install.on.demand("ranger", ...)
 
   # Fit all trees at once
-  fit <- ranger::ranger(x = xobs, y = yobs, num.trees = ntree)
+  extra_ranger_args <- list(...)
+  extra_ranger_args[["type"]] <- NULL # avoids unused argument warnings
+  fit <- do.call(
+    what = ranger::ranger,
+    args = c(list("x" = xobs, "y" = yobs, "num.trees" = ntree), extra_ranger_args)
+  )
 
   nodes <- predict(
     object = fit, data = rbind(xobs, xmis),

--- a/man/mice.impute.rf.Rd
+++ b/man/mice.impute.rf.Rd
@@ -36,8 +36,8 @@ alternative currently implemented is the \code{randomForest} package, which
 used to be the default in mice 3.13.10 and earlier.}
 
 \item{\dots}{Other named arguments passed down to
-\code{mice:::install.on.demand()}, \code{randomForest::randomForest()} and
-\code{randomForest:::randomForest.default()}.}
+\code{mice:::install.on.demand()}, \code{randomForest::randomForest()},
+\code{randomForest:::randomForest.default()}, and \code{ranger::ranger()}.}
 }
 \value{
 Vector with imputed data, same type as \code{y}, and of length


### PR DESCRIPTION
Hi! This PR allows to pass `...` arguments to `ranger::ranger()` when using `mice.impute.rf()`. 

- `...` was only being passed along when `rfPackage = "randomForest"`; should want the same behaviour with the now default `rfPackage = "ranger"`.
- I initially just changed `fit` to `ranger::ranger(x = xobs, y = yobs, num.trees = ntree, ...)`, but this triggers unused arguments warning for "type" (which I think is passed along to all `mice.impute.method` functions?). Hence, I use `list(...)`, set `extra_ranger_args[["type"]] <- NULL`, and proceed with `do.call()` to avoid this warning.
- Motivated in part because some of the extra `ranger()` arguments (e.g. `mtry`) can affect the quality of the imputations quite a bit.

