### PR TITLE
Prepare for deprecation of the blocks argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+* Prepares for the deprecation of the `blocks` argument at various places
+* Removes the need for `blocks` in `initialize_chain()`
+* In `rbind()`, when formulas are concatenated and duplicate names are found, also rename the duplicated variables in formulas by their new name
+* Fixes a bug in `filter.mids()` that incorrectly removed empty components in the `imp` object
+* Fixes a bug in `ibind()` that incorrectly used `length(blocks)` as the first dimension of the `chainMean` and `chainVar` objects
+* Corrects the description `visitSequence`, `chainMean` and `chainVar` components of the `mids` object
+
 # mice 3.16.5
 
 * Patches a bug in `complete()` that auto-repeated imputed values into cells that should NOT be imputed (occurred as a special case of `rbind()`, where the first set of rows was imputed and the second was not).

--- a/R/filter.R
+++ b/R/filter.R
@@ -94,8 +94,8 @@ filter.mids <- function(.data, ..., .preserve = FALSE) {
   for (i in names(.data$imp)) {
     wy <- .data$where[, i]
     iy <- .data$where[, i] & include
-
-    imp[[i]] <- .data$imp[[i]][iy[wy], , drop = FALSE]
+    impi <- .data$imp[[i]][iy[wy], , drop = FALSE]
+    if (!is.null(impi)) imp[[i]] <- impi
   }
 
   # Components that need to be recalculated/reset

--- a/R/ibind.R
+++ b/R/ibind.R
@@ -65,14 +65,14 @@ ibind <- function(x, y) {
   visitSequence <- x$visitSequence
   imp <- vector("list", ncol(x$data))
   names(imp) <- names(x$data)
-  for (j in visitSequence) {
+  for (j in names(imp)) {
     imp[[j]] <- cbind(x$imp[[j]], y$imp[[j]])
   }
 
   m <- (x$m + y$m)
   iteration <- max(x$iteration, y$iteration)
 
-  chainMean <- chainVar <- initialize.chain(x$blocks, iteration, m)
+  chainMean <- chainVar <- initialize.chain(names(x$data), iteration, m)
   for (j in seq_len(x$m)) {
     chainMean[, seq_len(x$iteration), j] <- x$chainMean[, , j]
     chainVar[, seq_len(x$iteration), j] <- x$chainVar[, , j]

--- a/R/initialize.chain.R
+++ b/R/initialize.chain.R
@@ -1,8 +1,7 @@
-initialize.chain <- function(blocks, maxit, m) {
-  vars <- unique(unlist(blocks))
-  chain <- array(NA, dim = c(length(vars), maxit, m))
+initialize.chain <- function(varnames, maxit, m) {
+  chain <- array(NA, dim = c(length(varnames), maxit, m))
   dimnames(chain) <- list(
-    vars,
+    varnames,
     seq_len(maxit),
     paste("Chain", seq_len(m))
   )

--- a/R/mids.R
+++ b/R/mids.R
@@ -14,9 +14,10 @@
 #'    following slots:}
 #'    \item{\code{data}:}{Original (incomplete) data set.}
 #'    \item{\code{imp}:}{A list of \code{ncol(data)} components with
-#'    the generated multiple imputations. Each list components is a
+#'    the generated multiple imputations. Each list component is a
 #'    \code{data.frame} (\code{nmis[j]} by \code{m}) of imputed values
-#'    for variable \code{j}.}
+#'    for variable \code{j}. A \code{NULL} component is used for
+#'    variables for which not imputations are generated.}
 #'    \item{\code{m}:}{Number of imputations.}
 #'    \item{\code{where}:}{The \code{where} argument of the
 #'    \code{mice()} function.}
@@ -29,7 +30,9 @@
 #'    specifying the imputation method per block.}
 #'    \item{\code{predictorMatrix}:}{A numerical matrix of containing
 #'    integers specifying the predictor set.}
-#'    \item{\code{visitSequence}:}{The sequence in which columns are visited.}
+#'    \item{\code{visitSequence}:}{A vector of variable and block names that
+#'     specifies how variables and blocks are visited in one iteration throuh
+#'     the data.}
 #'    \item{\code{formulas}:}{A named list of formula's, or expressions that
 #'    can be converted into formula's by \code{as.formula}. List elements
 #'    correspond to blocks. The block to which the list element applies is
@@ -43,13 +46,13 @@
 #'    \item{\code{seed}:}{The seed value of the solution.}
 #'    \item{\code{iteration}:}{Last Gibbs sampling iteration number.}
 #'    \item{\code{lastSeedValue}:}{The most recent seed value.}
-#'    \item{\code{chainMean}:}{A list of \code{m} components. Each
-#'    component is a \code{length(visitSequence)} by \code{maxit} matrix
-#'    containing the mean of the generated multiple imputations.
+#'    \item{\code{chainMean}:}{An array of dimensions \code{ncol} by
+#'    \code{maxit} by \code{m} elements containing the mean of
+#'    the generated multiple imputations.
 #'    The array can be used for monitoring convergence.
 #'    Note that observed data are not present in this mean.}
-#'    \item{\code{chainVar}:}{A list with similar structure of \code{chainMean},
-#'    containing the covariances of the imputed values.}
+#'    \item{\code{chainVar}:}{An array with similar structure as
+#'    \code{chainMean}, containing the variance of the imputed values.}
 #'    \item{\code{loggedEvents}:}{A \code{data.frame} with five columns
 #'    containing warnings, corrective actions, and other inside info.}
 #'    \item{\code{version}:}{Version number of \code{mice} package that

--- a/R/sampler.R
+++ b/R/sampler.R
@@ -9,7 +9,7 @@ sampler <- function(data, m, ignore, where, imp, blocks, method,
   r <- !is.na(data)
 
   # set up array for convergence checking
-  chainMean <- chainVar <- initialize.chain(blocks, maxit, m)
+  chainMean <- chainVar <- initialize.chain(names(data), maxit, m)
 
   ## THE MAIN LOOP: GIBBS SAMPLER ##
   if (maxit < 1) iteration <- 0

--- a/man/construct.blocks.Rd
+++ b/man/construct.blocks.Rd
@@ -42,7 +42,7 @@ specify models for the same block, the model for the
 specification given in \code{formulas}.
 }
 \examples{
-form <- name.formulas(list(bmi + hyp ~ chl + age, chl ~ bmi))
+form <- list(bmi + hyp ~ chl + age, chl ~ bmi)
 pred <- make.predictorMatrix(nhanes[, c("age", "chl")])
 construct.blocks(formulas = form, pred = pred)
 }

--- a/man/mids-class.Rd
+++ b/man/mids-class.Rd
@@ -55,9 +55,10 @@ equivalent \code{oldClass(obj) <- "mids"}.
    following slots:}
    \item{\code{data}:}{Original (incomplete) data set.}
    \item{\code{imp}:}{A list of \code{ncol(data)} components with
-   the generated multiple imputations. Each list components is a
+   the generated multiple imputations. Each list component is a
    \code{data.frame} (\code{nmis[j]} by \code{m}) of imputed values
-   for variable \code{j}.}
+   for variable \code{j}. A \code{NULL} component is used for
+   variables for which not imputations are generated.}
    \item{\code{m}:}{Number of imputations.}
    \item{\code{where}:}{The \code{where} argument of the
    \code{mice()} function.}
@@ -70,7 +71,9 @@ equivalent \code{oldClass(obj) <- "mids"}.
    specifying the imputation method per block.}
    \item{\code{predictorMatrix}:}{A numerical matrix of containing
    integers specifying the predictor set.}
-   \item{\code{visitSequence}:}{The sequence in which columns are visited.}
+   \item{\code{visitSequence}:}{A vector of variable and block names that
+    specifies how variables and blocks are visited in one iteration throuh
+    the data.}
    \item{\code{formulas}:}{A named list of formula's, or expressions that
    can be converted into formula's by \code{as.formula}. List elements
    correspond to blocks. The block to which the list element applies is
@@ -84,13 +87,13 @@ equivalent \code{oldClass(obj) <- "mids"}.
    \item{\code{seed}:}{The seed value of the solution.}
    \item{\code{iteration}:}{Last Gibbs sampling iteration number.}
    \item{\code{lastSeedValue}:}{The most recent seed value.}
-   \item{\code{chainMean}:}{A list of \code{m} components. Each
-   component is a \code{length(visitSequence)} by \code{maxit} matrix
-   containing the mean of the generated multiple imputations.
+   \item{\code{chainMean}:}{An array of dimensions \code{ncol} by
+   \code{maxit} by \code{m} elements containing the mean of
+   the generated multiple imputations.
    The array can be used for monitoring convergence.
    Note that observed data are not present in this mean.}
-   \item{\code{chainVar}:}{A list with similar structure of \code{chainMean},
-   containing the covariances of the imputed values.}
+   \item{\code{chainVar}:}{An array with similar structure as
+   \code{chainMean}, containing the variance of the imputed values.}
    \item{\code{loggedEvents}:}{A \code{data.frame} with five columns
    containing warnings, corrective actions, and other inside info.}
    \item{\code{version}:}{Version number of \code{mice} package that

--- a/tests/testthat/test-rbind.R
+++ b/tests/testthat/test-rbind.R
@@ -82,8 +82,8 @@ set.seed <- 818
 x <- rnorm(10)
 D <- data.frame(x = x, y = 2 * x + rnorm(10))
 D[c(2:4, 7), 1] <- NA
-#expect_error(D_mids <<- mice(D[1:5, ], print = FALSE), "`mice` detected constant and/or #collinear variables. No predictors were left after their removal.")
-expect_warning(D_mids <<- mice(D[1:5, ], print = FALSE, remove.collinear = TRUE))
+expect_error(D_mids <<- mice(D[1:5, ], print = FALSE),
+             "`mice` detected constant and/or collinear variables. No predictors were left after their removal.")
 expect_warning(D_mids <<- mice(D[1:5, ], print = FALSE, remove.collinear = FALSE))
 
 D_rbind <- mice:::rbind.mids(D_mids, D[6:10, ])


### PR DESCRIPTION
This PR prepares for the deprecation of the `blocks` argument at various places.

* Removes the need for `blocks` in `initialize_chain()`
* In `rbind()`, when formulas are concatenated and duplicate names are found, also rename the duplicated variables in formulas by their new name
* Fixes a bug in `filter.mids()` that incorrectly removed empty components in the `imp` object
* Fixes a bug in `ibind()` that incorrectly used `length(blocks)` as the first dimension of the `chainMean` and `chainVar` objects
* Corrects the description `visitSequence`, `chainMean` and `chainVar` components of the `mids` object
