### PR TITLE
ENH: skip missing data pattern check when `minpuc` == 0

### DIFF
--- a/R/quickpred.R
+++ b/R/quickpred.R
@@ -106,9 +106,11 @@ quickpred <- function(data, mincor = 0.1, minpuc = 0, include = "",
   predictorMatrix[maxc > mincor] <- 1
 
   # exclude predictors with a percentage usable cases below minpuc
-  p <- md.pairs(data)
-  puc <- p$mr / (p$mr + p$mm)
-  predictorMatrix[puc < minpuc] <- 0
+  if (minpuc != 0) {
+    p <- md.pairs(data)
+    puc <- p$mr / (p$mr + p$mm)
+    predictorMatrix[puc < minpuc] <- 0
+  }
 
   # exclude predictors listed in the exclude argument
   yz <- pmatch(exclude, names(data))


### PR DESCRIPTION
When datasets reach a particular size every extra action becomes prohibitively expensive. This change should help alleviate the problem a little bit.