### PR TITLE
CI: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This should make action management a bit easier. You only need to turn dependabot on in the repo settings. 

There's been some work done in https://github.com/dependabot/dependabot-core/issues/2042 (see links therein) to update the dependencies & run tests automatically, you might want to incorporate this as well.