### PR TITLE
FIX: resolve issue of element-wise comparison introduced in 4.3.0

### DIFF
--- a/R/predictorMatrix.R
+++ b/R/predictorMatrix.R
@@ -140,7 +140,10 @@ edit.predictorMatrix <- function(predictorMatrix,
                                  user.visitSequence,
                                  maxit) {
   # edit predictorMatrix to a monotone pattern
-  if (maxit == 1L && !is.null(user.visitSequence) && user.visitSequence == "monotone") {
+  if (maxit == 1L &&
+      !is.null(user.visitSequence) &&
+      length(user.visitSequence) == 1 &&
+      user.visitSequence == "monotone") {
     for (i in 1L:length(visitSequence)) {
       predictorMatrix[visitSequence[i], visitSequence[i:length(visitSequence)]] <- 0
     }


### PR DESCRIPTION
Running code 
```R
library("mice")
expr <- expression((wgt - 40) * (hc - 50))
boys$wgt.hc <- with(boys,  eval(expr))
meth <- make.method(boys)
meth["wgt.hc"] <- paste("~I(",  expr,  ")",  sep = "")
meth["bmi"] <- ""
pred <- make.predictorMatrix(boys)
pred[c("wgt",  "hc"),  "wgt.hc"] <- 0
imp.int <- mice(boys,  m = 1,  meth = meth,  pred = pred,  print = FALSE,  seed = 62587,  maxit = 10)


vis <- c("hgt",  "wgt",  "hc", "wgt.hc",  "gen",  "phb",  "tv",  "reg")
expr <- expression((wgt - 40) * (hc - 50))
boys$wgt.hc <- with(boys,  eval(expr))

imp.int2 <- mice(boys,  m = 1,  maxit = 1,  visitSequence = vis,
                 meth = imp.int$meth,  pred = imp.int$pred,
                 seed = 23390)

```

from Section `6.5.1` of the book results in the following error:
```R
Error in maxit == 1L && !is.null(user.visitSequence) && user.visitSequence ==  : 
  'length = 8' in coercion to 'logical(1)'
```
This is caused by [changes](https://cran.r-project.org/bin/windows/base/old/4.3.0/NEWS.R-4.3.0.html) introduced in `R4.3.0`. The PR should resolve this.
