### PR TITLE
"literanger" as alternative backend for random forest (faster prediction)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -67,6 +67,7 @@ Suggests:
     furrr,
     haven,
     knitr,
+    literanger,
     lme4,
     MASS,
     miceadds,

--- a/R/mice.impute.rf.R
+++ b/R/mice.impute.rf.R
@@ -80,6 +80,8 @@ mice.impute.rf <- function(y, ry, x, wy = NULL, ntree = 10,
 
   forest <- f(xobs, xmis, yobs, ntree, ...)
 
+  # Short-circuit when using literanger interface
+  if (rfPackage == "literanger") return(forest)
   # Sample from donors
   if (nmis == 1) forest <- array(forest, dim = c(1, ntree))
   apply(forest, MARGIN = 1, FUN = function(s) sample(unlist(s), 1))
@@ -142,9 +144,5 @@ mice.impute.rf <- function(y, ry, x, wy = NULL, ntree = 10,
   fit <- do.call(
     literanger::train, c(list(x = xobs, y = yobs, n_tree = ntree), dots)
   )
-  values <- predict(
-    object = fit, newdata = xmis,
-    prediction_type = "inbag"
-  )$values
-  array(values, dim = c(nrow(xmis), 1L))
+  predict(object = fit, newdata = xmis, prediction_type = "inbag")$values
 }

--- a/R/mice.impute.rf.R
+++ b/R/mice.impute.rf.R
@@ -6,12 +6,15 @@
 #' @inheritParams mice.impute.pmm
 #' @param ntree The number of trees to grow. The default is 10.
 #' @param rfPackage A single string specifying the backend for estimating the
-#' random forest. The default backend is the \code{ranger} package. The only
-#' alternative currently implemented is the \code{randomForest} package, which
-#' used to be the default in mice 3.13.10 and earlier.
+#' random forest. The default backend is the \code{ranger} package. An
+#' alternative is \code{literanger} which predicts faster but does not support
+#' all forest types and split rules from \code{ranger}. Also implemented as
+#' an alternative is the \code{randomForest} package, which used to be the
+#' default in mice 3.13.10 and earlier.
 #' @param \dots Other named arguments passed down to
 #' \code{mice:::install.on.demand()}, \code{randomForest::randomForest()},
-#' \code{randomForest:::randomForest.default()}, and \code{ranger::ranger()}.
+#' \code{randomForest:::randomForest.default()}, \code{ranger::ranger()}, and
+#' \code{literanger::train()}.
 #' @return Vector with imputed data, same type as \code{y}, and of length
 #' \code{sum(wy)}
 #' @details
@@ -44,8 +47,9 @@
 #' \href{https://stefvanbuuren.name/fimd/sec-cart.html}{\emph{Flexible Imputation of Missing Data. Second Edition.}}
 #' Chapman & Hall/CRC. Boca Raton, FL.
 #' @seealso \code{\link{mice}}, \code{\link{mice.impute.cart}},
-#' \code{\link[randomForest]{randomForest}}
-#' \code{\link[ranger]{ranger}}
+#' \code{\link[randomForest]{randomForest}},
+#' \code{\link[ranger]{ranger}},
+#' \code{\link[literanger]{train}}
 #' @family univariate imputation functions
 #' @keywords datagen
 #' @examples

--- a/man/mice.impute.rf.Rd
+++ b/man/mice.impute.rf.Rd
@@ -10,7 +10,7 @@ mice.impute.rf(
   x,
   wy = NULL,
   ntree = 10,
-  rfPackage = c("ranger", "randomForest"),
+  rfPackage = c("ranger", "randomForest", "literanger"),
   ...
 )
 }
@@ -31,13 +31,16 @@ indicates locations in \code{y} for which imputations are created.}
 \item{ntree}{The number of trees to grow. The default is 10.}
 
 \item{rfPackage}{A single string specifying the backend for estimating the
-random forest. The default backend is the \code{ranger} package. The only
-alternative currently implemented is the \code{randomForest} package, which
-used to be the default in mice 3.13.10 and earlier.}
+random forest. The default backend is the \code{ranger} package. An
+alternative is \code{literanger} which predicts faster but does not support
+all forest types and split rules from \code{ranger}. Also implemented as
+an alternative is the \code{randomForest} package, which used to be the
+default in mice 3.13.10 and earlier.}
 
 \item{\dots}{Other named arguments passed down to
 \code{mice:::install.on.demand()}, \code{randomForest::randomForest()},
-\code{randomForest:::randomForest.default()}, and \code{ranger::ranger()}.}
+\code{randomForest:::randomForest.default()}, \code{ranger::ranger()}, and
+\code{literanger::train()}.}
 }
 \value{
 Vector with imputed data, same type as \code{y}, and of length
@@ -85,8 +88,9 @@ Chapman & Hall/CRC. Boca Raton, FL.
 }
 \seealso{
 \code{\link{mice}}, \code{\link{mice.impute.cart}},
-\code{\link[randomForest]{randomForest}}
-\code{\link[ranger]{ranger}}
+\code{\link[randomForest]{randomForest}},
+\code{\link[ranger]{ranger}},
+\code{\link[literanger]{train}}
 
 Other univariate imputation functions: 
 \code{\link{mice.impute.cart}()},

--- a/tests/testthat/test-mice.impute.rf.R
+++ b/tests/testthat/test-mice.impute.rf.R
@@ -26,5 +26,6 @@
 #   {
 #     expect_visible(do.call(mice.impute.rf, c(par, list(rfPackage = "ranger"))))
 #     expect_visible(do.call(mice.impute.rf, c(par, list(rfPackage = "randomForest"))))
+#     expect_visible(do.call(mice.impute.rf, c(par, list(rfPackage = "literanger"))))
 #   }
 # )


### PR DESCRIPTION
Offer the "literanger" package as an alternative backend for faster prediction from random forest models.

literanger is more-or-less the same algorithm as ranger but with a refactored interface that reduces overhead in prediction (fewer copy semantics and more generous use of templates on the C++ side).

It uses a marginally different (but generally equivalent) procedure for drawing the predicted value. A randomly selected tree is drawn first (for each missing value) and then a randomly selected observed value is drawn from the leaf node (that the missing value belongs to).

Not all forest types and split rules from the original ranger package, however, are currently supported.

Here's some short examples of the difference in elapsed time on my laptop (Ryzen 4900HS Ubuntu 22.04)

```r
require(microbenchmark)
require(mice)
require(ranger)
require(literanger)
set.seed(1234L)

# Add MCAR to iris
prop_missing <- 0.2
data_iris <- iris
n_prod_m <- prod(dim(data_iris))
data_iris[arrayInd(sample.int(n_prod_m, size=n_prod_m * prop_missing),
                   .dim=dim(data_iris))] <- NA

microbenchmark(
    res <- mice(data_iris, m=5L, maxit=10L, method='rf', printFlag=FALSE,
                rfPackage='ranger'),
    res <- mice(data_iris, m=5L, maxit=10L, method='rf', printFlag=FALSE,
                rfPackage='literanger'),
    times=10L
)
#      min       lq     mean   median       uq      max neval
#  2.690511 2.716136 2.750803 2.726515 2.773808 2.857036    10
#  1.095654 1.108470 1.125039 1.118390 1.123107 1.214325    10

# Add MCAR to a larger, multivariate-normal dataset
n_dim <- 5E1
n_obs <- 5E3
chol_sigma <- matrix(rnorm(n_dim^2), nrow=n_dim)
data_mvn <- matrix(rnorm(n_obs * n_dim), nrow=n_obs, ncol=n_dim) %*% chol_sigma
colnames(data_mvn) <- make.names(seq_len(n_dim))

n_prod_m <- prod(dim(data_mvn))
data_mvn[arrayInd(sample.int(n_prod_m, size=n_prod_m * prop_missing),
                  .dim=dim(data_mvn))] <- NA
data_mvn <- as.data.frame(data_mvn)

microbenchmark(
    res <- mice(data_mvn, m=5L, maxit=10L, method='rf', printFlag=FALSE,
                rfPackage='ranger'),
    res <- mice(data_mvn, m=5L, maxit=10L, method='rf', printFlag=FALSE,
                rfPackage='literanger'),
    times=5L
)
#      min       lq     mean   median       uq      max neval
#  579.4787 579.7766 581.0646 580.3888 582.7379 582.9408     5
#  272.8672 273.7151 274.1525 274.2950 274.7915 275.0935     5
```