### PR TITLE
Fix ordered factor problem in augment (#713)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,18 @@
+- Fixed a long-standing issue in the internal `augment()` function that affected ordered factors. 
+  Previously, `augment()` would:
+  
+  1. Convert ordered factors into unordered ones, and  
+  2. Reorder their levels alphabetically, ignoring the user-specified order.
+
+  This behavior could degrade imputation quality for ordinal outcomes when using the `"polr"` method, 
+  potentially causing model convergence issues or increased noise in imputations.
+
+  The issue did not affect methods for unordered factors (`"logreg"`, `"polyreg"`, `"mnar.logreg"`), 
+  where level order is inconsequential. 
+
+  Thanks to @mmansolf for identifying the problem and suggesting a fix. The updated `augment()` now 
+  correctly preserves the `ordered` class and level order of factor variables.
+- Updates security dependabot to `dawidd6/action-download-artifact@v6`
 
 # mice 3.17.6
 

--- a/R/mice.impute.logreg.R
+++ b/R/mice.impute.logreg.R
@@ -188,7 +188,13 @@ augment <- function(y, ry, x, wy, maxcat = 50) {
   xa <- rbind.data.frame(x, d)
 
   # beware, concatenation of factors
-  ya <- if (is.factor(y)) as.factor(levels(y)[c(y, e)]) else c(y, e)
+  ya <- if (is.factor(y)) {
+    if (is.ordered(y)) {
+      ordered(levels(y)[c(y, e)], levels = levels(y))
+    } else {
+      as.factor(levels(y)[c(y, e)])
+    }
+  } else c(y, e)
   rya <- c(ry, rep.int(TRUE, nr))
   wya <- c(wy, rep.int(FALSE, nr))
   wa <- c(rep.int(1, length(y)), rep.int((p + 1) / nr, nr))


### PR DESCRIPTION
This PR fixes a long-standing issue in the internal `augment()` function that affected ordered factors. 

Previously, `augment()` would:
  
  1. Convert ordered factors into unordered ones, and  
  2. Reorder their levels alphabetically, ignoring the user-specified order.

This behavior could degrade imputation quality for ordinal outcomes when using the `"polr"` method, potentially causing model convergence issues or increased noise in imputations.

The issue did not affect methods for unordered factors (`"logreg"`, `"polyreg"`, `"mnar.logreg"`), where level order is inconsequential. 

Thanks to @mmansolf for identifying the problem and suggesting a fix. The updated `augment()` now correctly preserves the `ordered` class and level order of factor variables.