### PR TITLE
explicitly load 'toenail' data from the 'mice' package (avoid 'lme4' conflict)

### DIFF
--- a/tests/testthat/test-mice.impute.2l.bin.R
+++ b/tests/testthat/test-mice.impute.2l.bin.R
@@ -26,7 +26,7 @@ test_that("mice::mice.impute.2l.bin() accepts factor outcome", {
 })
 
 # toenail: outcome is 0/1
-data("toenail")
+data("toenail", package = "mice")
 data <- tidyr::complete(toenail, ID, visit) %>%
   tidyr::fill(treatment) %>%
   dplyr::select(-month)


### PR DESCRIPTION
`lme4` now provides a version of the toenail data set, which matches `toenail2` in this package (and has a column-name mismatch with `toenail` in this package). Changed one instance of `data("toenail")` to `data("toenail", package="mice")` in the tests ...