### PR TITLE
Fix bug ampute(run = FALSE)

### DIFF
--- a/R/ampute.R
+++ b/R/ampute.R
@@ -208,7 +208,6 @@ ampute <- function(data, prop = 0.5, patterns = NULL, freq = NULL,
   if (is.null(data)) {
     stop("Argument data is missing, with no default", call. = FALSE)
   }
-  # data.in <- data # preserve an original set to inject the NA's in later
   data <- check.dataform(data)
   if (anyNA(data)) {
     stop("Data cannot contain NAs", call. = FALSE)


### PR DESCRIPTION
1. Remove `data.in` line, because I keep the original data as is, and make a new object for the numeric data.
2. Directly remove values from the `data.in`, instead of creating an intermediate `missing.data` object.
3. Remove `as.data.frame(data)` because `check.dataform(data)` already transforms to `data.frame`.