### PR TITLE
Updating nelsonaalen() to pass args to coxph() + stop returning NAs when near-ties are corrected

### DIFF
--- a/R/nelsonaalen.R
+++ b/R/nelsonaalen.R
@@ -11,6 +11,7 @@
 #' @param data A data frame containing the data.
 #' @param timevar The name of the time variable in \code{data}.
 #' @param statusvar The name of the event variable, e.g. death in \code{data}.
+#' @param \dots Other named arguments passed down to \code{survival::coxph()}
 #' @return A vector with \code{nrow(data)} elements containing the Nelson-Aalen
 #' estimates of the cumulative hazard function.
 #' @author Stef van Buuren, 2012
@@ -36,7 +37,7 @@
 #' ch <- nelsonaalen(eng, time, status)
 #' plot(x = time, y = ch, ylab = "Cumulative hazard", xlab = "Time")
 #' @export
-nelsonaalen <- function(data, timevar, statusvar) {
+nelsonaalen <- function(data, timevar, statusvar, ...) {
   if (!is.data.frame(data)) {
     stop("Data must be a data frame")
   }
@@ -45,7 +46,12 @@ nelsonaalen <- function(data, timevar, statusvar) {
   time <- data[, timevar, drop = TRUE]
   status <- data[, statusvar, drop = TRUE]
 
-  hazard <- survival::basehaz(survival::coxph(survival::Surv(time, status) ~ 1))
-  idx <- match(time, hazard[, "time"])
+  coxph_obj <- survival::coxph(survival::Surv(time, status) ~ 1, ...)
+  hazard <- survival::basehaz(coxph_obj)
+  
+  # Adjust depending on near-tie correction
+  idx <- if (coxph_obj$timefix) {
+    match(coxph_obj$y[, "time"], hazard[, "time"])
+  } else match(time, hazard[, "time"])
   hazard[idx, "hazard"]
 }

--- a/man/nelsonaalen.Rd
+++ b/man/nelsonaalen.Rd
@@ -5,7 +5,7 @@
 \alias{hazard}
 \title{Cumulative hazard rate or Nelson-Aalen estimator}
 \usage{
-nelsonaalen(data, timevar, statusvar)
+nelsonaalen(data, timevar, statusvar, ...)
 }
 \arguments{
 \item{data}{A data frame containing the data.}
@@ -13,6 +13,8 @@ nelsonaalen(data, timevar, statusvar)
 \item{timevar}{The name of the time variable in \code{data}.}
 
 \item{statusvar}{The name of the event variable, e.g. death in \code{data}.}
+
+\item{\dots}{Other named arguments passed down to \code{survival::coxph()}}
 }
 \value{
 A vector with \code{nrow(data)} elements containing the Nelson-Aalen


### PR DESCRIPTION
Dear @stefvanbuuren,

`mice::nelsonaalen()` returns NAs when there are near-ties (which are corrected by default by `survival::aeqSurv()`, see [here](https://cran.r-project.org/web/packages/survival/vignettes/tiedtimes.pdf)) in the data, which can occur especially in simulations - see reproducible example further down below.

This small pull request allows to pass arguments to `coxph()` with `...` (allowing e.g. to set `timefix = FALSE`, when the user does not want the near-tie correction), but also returns the cumulative hazard properly without any NAs by matching with the timefixed version of time variable in `<coxph_object>$y[, "time"]` with the default `timefix = TRUE`.

Do let me know if I need to edit anything / if I potentially need to write a unit test. Thanks!

``` r
library(mice)
#> Warning: package 'mice' was built under R version 4.5.2
#> 
#> Attaching package: 'mice'
#> The following object is masked from 'package:stats':
#> 
#>     filter
#> The following objects are masked from 'package:base':
#> 
#>     cbind, rbind
library(survival)
set.seed(8994948)
n <- 2500
dat <- cbind.data.frame(id = seq_len(n), time = rexp(n, rate = 25), delta = 1)
dat$nels <- nelsonaalen(dat, timevar = "time", statusvar = "delta")
dat <- dat[order(dat$time), ]

sum(is.na(dat$nels))
#> [1] 2
relevant_ids <- as.numeric(outer(which(is.na(dat$nels)), seq(-2, 2), FUN = "+"))
dat[sort(relevant_ids), ]
#>        id        time delta       nels
#> 1127 1127 0.004041275     1 0.09869523
#> 1235 1235 0.004048617     1 0.09957842
#> 650   650 0.004048624     1         NA
#> 2442 2442 0.004052250     1 0.10002031
#> 722   722 0.004064549     1 0.10046240
#> 1835 1835 0.016972630     1 0.40937194
#> 1607 1607 0.017028779     1 0.41057712
#> 377   377 0.017028781     1         NA
#> 2237 2237 0.017036829     1 0.41118026
#> 2072 2072 0.017038318     1 0.41178376
```

<sup>Created on 2026-03-23 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
