### PR TITLE
Replace partial matches with full matches

### DIFF
--- a/R/mice.impute.norm.R
+++ b/R/mice.impute.norm.R
@@ -125,7 +125,7 @@ estimice <- function(x, y, ls.meth = "qr", ridge = 1e-05, ...) {
   df <- max(length(y) - ncol(x), 1)
   if (ls.meth == "qr") {
     qr <- lm.fit(x = x, y = y)
-    c <- t(qr$coef)
+    c <- t(qr$coefficients)
     f <- qr$fitted.values
     r <- t(qr$residuals)
     v <- try(solve(as.matrix(crossprod(qr.R(qr$qr)))), silent = TRUE)

--- a/R/pool.r.squared.R
+++ b/R/pool.r.squared.R
@@ -107,6 +107,6 @@ pool.r.squared <- function(object, adjusted = FALSE) {
     (1 + exp(2 * (qbar - 1.96 * sqrt(fit$t)))))^2
   table[, 3] <- ((exp(2 * (qbar + 1.96 * sqrt(fit$t))) - 1) /
     (1 + exp(2 * (qbar + 1.96 * sqrt(fit$t)))))^2
-  table[, 4] <- fit$f
+  table[, 4] <- fit$fmi
   table
 }


### PR DESCRIPTION
When using the `mice()` function with `options(warnPartialMatchDollar = TRUE)` I noticed some warnings regarding partial matches.

Running

```r
options(warnPartialMatchDollar = TRUE)
devtools::test()
```

I found two occurences of partial matches, which are now replaced with full matches.

In `R/mice.impute.norm.R`
```r
c <- t(qr$coef) # partial match to coefficients
```

and in `R/pool.r.squared.R`
```r
table[, 4] <- fit$f # partial match to f
```