### PR TITLE
Fix typo in NEWS.md

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,7 +24,7 @@
 
 - Adds `mice.impute.svm()` as a binary variables imputation technique for high 
   dimensional data based on proper multiple imputation using Support Vector 
-  Machines combined with bootstrapping. Solves (#751) with (#752). Thanks @Mmtakahashi123
+  Machines combined with bootstrapping. Solves (#751) with (#752). Thanks @mtakahashi123
 
 # mice 3.19.8
 


### PR DESCRIPTION
Hi mice team,

This is a minor PR to fix a typo in my GitHub handle in the `mice 3.19.9` section of the NEWS file. It was written as `@Mmtakahashi123` with an extra 'M', so this PR corrects it to `@mtakahashi123` to restore the hyperlink.

Thank you!